### PR TITLE
Fix prompt creation: use a fetcher with a pinned action

### DIFF
--- a/app/modules/teams/containers/teamPrompts.route.tsx
+++ b/app/modules/teams/containers/teamPrompts.route.tsx
@@ -2,20 +2,19 @@ import find from "lodash/find";
 import { useEffect } from "react";
 import {
   redirect,
-  useActionData,
+  useFetcher,
   useLoaderData,
   useNavigate,
   useOutletContext,
   useParams,
   useSearchParams,
-  useSubmit,
 } from "react-router";
 import trackServerEvent from "~/modules/analytics/helpers/trackServerEvent.server";
 import buildQueryFromParams from "~/modules/app/helpers/buildQueryFromParams";
 import getQueryParamsFromRequest from "~/modules/app/helpers/getQueryParamsFromRequest.server";
 import { useSearchQueryParams } from "~/modules/app/hooks/useSearchQueryParams";
 import requireAuth from "~/modules/authentication/helpers/requireAuth";
-import addDialog from "~/modules/dialogs/addDialog";
+import addDialog, { closeDialog } from "~/modules/dialogs/addDialog";
 import PromptAuthorization from "~/modules/prompts/authorization";
 import CreatePromptDialog from "~/modules/prompts/components/createPromptDialog";
 import {
@@ -121,8 +120,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 export default function TeamPromptsRoute() {
   const data = useLoaderData<typeof loader>();
   const ctx = useOutletContext<{ team: Team }>();
-  const actionData = useActionData();
-  const submit = useSubmit();
+  const fetcher = useFetcher();
   const navigate = useNavigate();
   const params = useParams();
   const teamId = params.teamId;
@@ -148,16 +146,18 @@ export default function TeamPromptsRoute() {
   });
 
   useEffect(() => {
-    if (actionData?.intent === "CREATE_PROMPT") {
+    if (fetcher.state !== "idle" || !fetcher.data) return;
+    if (fetcher.data.intent === "CREATE_PROMPT" && fetcher.data.data) {
+      closeDialog();
       navigate(
         promptsUrl(
           teamId!,
-          actionData.data._id,
-          actionData.data.productionVersion,
+          fetcher.data.data._id,
+          fetcher.data.data.productionVersion,
         ),
       );
     }
-  }, [actionData, navigate, teamId]);
+  }, [fetcher.state, fetcher.data, navigate, teamId]);
 
   const onCreatePromptButtonClicked = () => {
     addDialog(
@@ -187,12 +187,16 @@ export default function TeamPromptsRoute() {
     name: string;
     annotationType: string;
   }) => {
-    submit(
+    fetcher.submit(
       JSON.stringify({
         intent: "CREATE_PROMPT",
         payload: { name, annotationType },
       }),
-      { method: "POST", encType: "application/json" },
+      {
+        method: "POST",
+        action: promptsUrl(teamId!),
+        encType: "application/json",
+      },
     );
   };
 

--- a/e2e/prompts.spec.ts
+++ b/e2e/prompts.spec.ts
@@ -138,6 +138,10 @@ test.describe("Prompts", () => {
 
     await expect(page).toHaveURL(/\/teams\/[a-f0-9]+\/prompts\/[a-f0-9]+\/1$/);
     await expect(page.getByText(promptName)).toBeVisible();
+
+    await expect(
+      page.getByRole("dialog", { name: "Create a new prompt" }),
+    ).toBeHidden();
   });
 
   test("should create a new version of existing prompt", async ({ page }) => {


### PR DESCRIPTION
## Summary

On `/teams/:teamId/prompts`, creating a prompt submitted `CREATE_PROMPT` via `useSubmit` and then navigated to the editor. `useSubmit` posts to whatever route is current at submit time, so the lingering `CreatePromptDialog` (a single global modal) could re-submit `CREATE_PROMPT` to the now-current **editor** action, which ran `PromptVersionService.findById(undefined)` and threw "Prompt version not found".

Symptoms reported:
1. The "Create a new prompt" dialog stayed open after the prompt was created.
2. Clicking "Create prompt" again threw `Error: Prompt version not found` (`promptEditor.route.tsx:93`).

## Fix

Switch prompt creation to `useFetcher` with an explicit `action` (the prompts route URL), mirroring team creation (`useCreateTeam`) and the "useFetcher for client-side feedback before navigating" convention in AGENTS.md. This pins the submit target regardless of navigation, so the second-click misfire is structurally impossible. `closeDialog()` in the success effect dismisses the modal once the prompt is created.

## Test

Added an e2e assertion that the create dialog is hidden after creation (`e2e/prompts.spec.ts`). It reproduces the original bug — red on the old code (`Received: visible`), green with the fix.

Verified team creation does not share the bug: its dialog wraps the submit button in `DialogClose`, and it already submits via `useFetcher` with an explicit `action`.

Fixes #2405