### PR TITLE
Make sidebar logo return to home screen

### DIFF
--- a/app/modules/app/components/appSidebar.tsx
+++ b/app/modules/app/components/appSidebar.tsx
@@ -207,7 +207,7 @@ export default function AppSidebar() {
             </div>
           </div>
         ) : (
-          <Link to={activeTeamId ? projectsUrl(activeTeamId) : "/"}>
+          <Link to="/">
             <img
               src={sandpiperLogo}
               alt="Sandpiper"


### PR DESCRIPTION
The top-left Sandpiper logo linked to the active team's projects page and only fell back to "/" when there was no active team. Link it to the home screen ("/") unconditionally so the logo behaves as a home affordance.

Fixes #2427