### PR TITLE
Fix session viewer on small-screen laptops

### DIFF
--- a/app/modules/sessions/components/runSessionViewer.tsx
+++ b/app/modules/sessions/components/runSessionViewer.tsx
@@ -182,7 +182,7 @@ export default function SessionViewer({
               </div>
             </div>
             <div className="my-6">
-              <div className="flex items-center justify-between">
+              <div className="flex flex-wrap items-center justify-between gap-2">
                 <Button
                   variant="outline"
                   className="text-xs"

--- a/app/modules/sessions/components/runSessionViewer.tsx
+++ b/app/modules/sessions/components/runSessionViewer.tsx
@@ -118,7 +118,7 @@ export default function SessionViewer({
       <div
         id="session-annotations-panel"
         tabIndex={-1}
-        className="flex h-full w-2/5 min-w-0 flex-col pt-8"
+        className="flex h-full w-2/5 min-w-0 flex-col overflow-y-auto pt-8"
       >
         <div className="border-b px-4 pb-4">
           <SessionViewerDetails
@@ -134,11 +134,11 @@ export default function SessionViewer({
           />
         </div>
         {sessionFile.annotations && sessionFile.annotations.length > 0 && (
-          <div className="flex min-h-0 flex-1 flex-col p-4 pb-0">
+          <div className="flex flex-col p-4 pb-0">
             <div className="text-muted-foreground mb-2">
               Session annotations
             </div>
-            <div className="min-h-0 flex-1 overflow-y-auto">
+            <div>
               {map(sessionFile.annotations, (annotation, index) => {
                 return (
                   <SessionViewerAnnotation
@@ -172,7 +172,7 @@ export default function SessionViewer({
         )}
         {(annotatedUtteranceCount > 0 ||
           (shouldShowVerificationDetails && removedAnnotations.length > 0)) && (
-          <div className="flex min-h-0 flex-1 flex-col p-4 pb-0">
+          <div className="flex flex-col p-4 pb-0">
             <div className="mb-2 flex items-center justify-between">
               <div>
                 View Annotations
@@ -226,7 +226,7 @@ export default function SessionViewer({
                 </div>
               </div>
             </div>
-            <div className="min-h-0 flex-1 overflow-y-auto">
+            <div>
               {map(selectedUtteranceAnnotations, (annotation, index) => {
                 return (
                   <SessionViewerAnnotation

--- a/app/modules/sessions/components/runSessionViewerDetails.tsx
+++ b/app/modules/sessions/components/runSessionViewerDetails.tsx
@@ -14,11 +14,11 @@ export default function RunSessionViewerDetails({
 }: RunSessionViewerDetailsProps) {
   return (
     <div className="mb-2">
-      <div className="mb-2 flex items-center justify-between">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
         <span className="text-muted-foreground">Started</span>
         <span className="text-right">{getDateString(session.startedAt)}</span>
       </div>
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
         <span className="text-muted-foreground">Finished</span>
         <span className="text-right">{getDateString(session.finishedAt)}</span>
       </div>

--- a/app/modules/sessions/components/sessionListSidebar.tsx
+++ b/app/modules/sessions/components/sessionListSidebar.tsx
@@ -45,7 +45,7 @@ export default function SessionListSidebar({
   }, []);
 
   return (
-    <div className="flex h-full w-60 shrink-0 flex-col border-r">
+    <div className="flex h-full w-[clamp(9rem,14vw,15rem)] shrink-0 flex-col border-r">
       <div className="border-b p-3">
         <div className="relative">
           <SearchIcon className="text-muted-foreground absolute top-2.5 left-3 size-4" />

--- a/app/modules/sessions/components/sessionVerification.tsx
+++ b/app/modules/sessions/components/sessionVerification.tsx
@@ -12,10 +12,10 @@ export default function SessionVerification({
 }) {
   return (
     <div className="py-2">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
         <span className="text-muted-foreground text-sm">Verification</span>
         <div className="flex items-center gap-2">
-          <span className="text-muted-foreground text-xs">
+          <span className="text-muted-foreground text-xs whitespace-nowrap">
             Show verifications
           </span>
           <Switch


### PR DESCRIPTION
## What

Fixes #2430 — on short-screen laptops the session annotations were invisible and unreachable, and the panels degraded poorly at narrow widths.

## Commits

**1. Make session annotations panel scroll on short screens** (`Fixes #2430`)

The right annotations panel stacked a non-shrinking details/summary block above `flex-1` annotation regions inside a viewport-height-locked box. On short viewports the details block consumed the box, collapsing the annotation regions to zero; the overflow was `overflow: visible` so it painted below the box without adding to document scroll height, leaving annotations unreachable (zooming out was the only workaround the reporter found).

The panel is now a single `overflow-y-auto` column, so details and annotations stack at natural height and scroll together.

**2. Make session viewer panels degrade gracefully at narrow widths**

Opportunistic fixes for narrow-width breakage in the same panel:
- Verification header, annotation nav row, and dates now wrap instead of colliding/clipping.
- Session list uses a fluid `clamp(9rem,14vw,15rem)` width so it gives up width first when space is tight, keeping the transcript and annotation columns usable.

Verified visually on short and narrow windows.