### PR TITLE
Improve session annotations panel readability

### DIFF
--- a/app/modules/sessions/components/runSessionViewer.tsx
+++ b/app/modules/sessions/components/runSessionViewer.tsx
@@ -83,7 +83,7 @@ export default function SessionViewer({
       </SkipLink>
       <div
         id="session-viewer-scroll-container"
-        className="flex h-full w-3/5 min-w-0 flex-col overflow-y-scroll scroll-smooth border-r p-4"
+        className="flex h-full w-[55%] min-w-0 flex-col overflow-y-scroll scroll-smooth border-r p-4"
       >
         {map(sessionFile.transcript, (utterance: Utterance, index: number) => {
           const isSelected = selectedUtteranceId === utterance._id;
@@ -118,7 +118,7 @@ export default function SessionViewer({
       <div
         id="session-annotations-panel"
         tabIndex={-1}
-        className="flex h-full w-2/5 min-w-0 flex-col overflow-y-auto pt-8"
+        className="flex h-full w-[45%] min-w-0 flex-col overflow-y-auto pt-4"
       >
         <div className="border-b px-4 pb-4">
           <SessionViewerDetails

--- a/app/modules/sessions/components/runSessionViewerAnnotation.tsx
+++ b/app/modules/sessions/components/runSessionViewerAnnotation.tsx
@@ -2,19 +2,12 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import clsx from "clsx";
-import map from "lodash/map";
 import { Check, ThumbsDown, ThumbsUp } from "lucide-react";
 import { useState } from "react";
+import getOrderedAnnotationKeys from "../helpers/getOrderedAnnotationKeys";
 import type { Annotation } from "../sessions.types";
 import SessionViewerAnnotationValue from "./runSessionViewerAnnotationValue";
 import SessionViewerAnnotationVerificationStatus from "./runSessionViewerAnnotationVerificationStatus";
-
-const HIDDEN_ANNOTATION_KEYS = new Set([
-  "_id",
-  "identifiedBy",
-  "markedAs",
-  "votingReason",
-]);
 
 export default function SessionViewerAnnotation({
   annotation,
@@ -51,11 +44,8 @@ export default function SessionViewerAnnotation({
         isChangedByVerification={isChangedByVerification}
         isAddedByVerification={isAddedByVerification}
       />
-      {map(annotation, (annotationValue, annotationKey) => {
-        if (HIDDEN_ANNOTATION_KEYS.has(annotationKey)) {
-          return null;
-        }
-
+      {getOrderedAnnotationKeys(annotation).map((annotationKey) => {
+        const annotationValue = annotation[annotationKey];
         const previousValue = preAnnotation?.[annotationKey];
         const hasChanged =
           isChangedByVerification &&
@@ -63,7 +53,7 @@ export default function SessionViewerAnnotation({
           String(previousValue) !== String(annotationValue);
 
         return (
-          <div className="mb-2" key={annotationKey}>
+          <div className="mb-2 break-words" key={annotationKey}>
             <div className="text-muted-foreground text-caption">
               {annotationKey}
             </div>

--- a/app/modules/sessions/components/runSessionViewerDetails.tsx
+++ b/app/modules/sessions/components/runSessionViewerDetails.tsx
@@ -27,22 +27,22 @@ export default function RunSessionViewerDetails({
         </span>
       </div>
       {annotatedUtteranceCount > 0 && (
-        <div className="mt-2 mb-4">
-          <div className="text-muted-foreground text-body mb-4 font-medium">
+        <div className="mt-2 mb-2">
+          <div className="text-muted-foreground text-body mb-2 font-medium">
             Summary
           </div>
           <div className="grid grid-cols-2 gap-3">
-            <div className="bg-card flex flex-col items-center rounded-lg border p-3">
+            <div className="bg-card flex flex-col items-center rounded-lg border p-2">
               <div className="text-muted-foreground text-caption mb-1">
                 Total utterances
               </div>
-              <div className="text-display font-bold">{utteranceCount}</div>
+              <div className="text-heading font-bold">{utteranceCount}</div>
             </div>
-            <div className="bg-card flex flex-col items-center rounded-lg border p-3">
+            <div className="bg-card flex flex-col items-center rounded-lg border p-2">
               <div className="text-muted-foreground text-caption mb-1">
                 Annotated
               </div>
-              <div className="text-display font-bold">
+              <div className="text-heading font-bold">
                 {annotatedUtteranceCount}
               </div>
             </div>

--- a/app/modules/sessions/components/sessionListSidebar.tsx
+++ b/app/modules/sessions/components/sessionListSidebar.tsx
@@ -45,7 +45,7 @@ export default function SessionListSidebar({
   }, []);
 
   return (
-    <div className="flex h-full w-[clamp(9rem,14vw,15rem)] shrink-0 flex-col border-r">
+    <div className="flex h-full w-[clamp(8rem,12vw,13rem)] shrink-0 flex-col border-r">
       <div className="border-b p-3">
         <div className="relative">
           <SearchIcon className="text-muted-foreground absolute top-2.5 left-3 size-4" />

--- a/app/modules/sessions/helpers/__tests__/getOrderedAnnotationKeys.test.ts
+++ b/app/modules/sessions/helpers/__tests__/getOrderedAnnotationKeys.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import getOrderedAnnotationKeys from "../getOrderedAnnotationKeys";
+
+describe("getOrderedAnnotationKeys", () => {
+  it("orders schema fields alphabetically with reasoning last", () => {
+    const annotation = {
+      _id: "1",
+      identifiedBy: "AI",
+      reasoning: "Because...",
+      MOVE_TYPE: "PROBE",
+      HELP_TYPE: "HINT",
+    };
+
+    expect(getOrderedAnnotationKeys(annotation)).toEqual([
+      "HELP_TYPE",
+      "MOVE_TYPE",
+      "reasoning",
+    ]);
+  });
+
+  it("returns the same order regardless of key insertion order", () => {
+    const first = {
+      _id: "1",
+      identifiedBy: "AI",
+      reasoning: "r",
+      MOVE_TYPE: "PROBE",
+      HELP_TYPE: "HINT",
+    };
+    const second = {
+      _id: "2",
+      reasoning: "r",
+      HELP_TYPE: "HINT",
+      identifiedBy: "AI",
+      MOVE_TYPE: "PROBE",
+    };
+
+    expect(getOrderedAnnotationKeys(first)).toEqual(
+      getOrderedAnnotationKeys(second),
+    );
+  });
+
+  it("excludes hidden bookkeeping keys", () => {
+    const annotation = {
+      _id: "1",
+      identifiedBy: "AI",
+      markedAs: "UP_VOTED" as const,
+      votingReason: "good",
+      SCORE: 3,
+    };
+
+    expect(getOrderedAnnotationKeys(annotation)).toEqual(["SCORE"]);
+  });
+
+  it("keeps reasoning when it is the only visible field", () => {
+    const annotation = {
+      _id: "1",
+      identifiedBy: "AI",
+      reasoning: "r",
+    };
+
+    expect(getOrderedAnnotationKeys(annotation)).toEqual(["reasoning"]);
+  });
+
+  it("handles annotations without a reasoning field", () => {
+    const annotation = {
+      _id: "1",
+      identifiedBy: "AI",
+      B_FIELD: "b",
+      A_FIELD: "a",
+    };
+
+    expect(getOrderedAnnotationKeys(annotation)).toEqual([
+      "A_FIELD",
+      "B_FIELD",
+    ]);
+  });
+});

--- a/app/modules/sessions/helpers/getOrderedAnnotationKeys.ts
+++ b/app/modules/sessions/helpers/getOrderedAnnotationKeys.ts
@@ -1,0 +1,21 @@
+import type { Annotation } from "../sessions.types";
+
+const HIDDEN_ANNOTATION_KEYS = new Set([
+  "_id",
+  "identifiedBy",
+  "markedAs",
+  "votingReason",
+]);
+
+export default function getOrderedAnnotationKeys(
+  annotation: Annotation,
+): string[] {
+  const keys = Object.keys(annotation).filter(
+    (key) => !HIDDEN_ANNOTATION_KEYS.has(key) && key !== "reasoning",
+  );
+  keys.sort((a, b) => a.localeCompare(b));
+  if ("reasoning" in annotation) {
+    keys.push("reasoning");
+  }
+  return keys;
+}


### PR DESCRIPTION
Give the annotations panel half the viewer width, narrow the session list slightly, compact the details summary, and wrap long values. Render annotation fields in a stable alphabetical order with reasoning always last so the layout is consistent across annotations.

Fixes #2444