### PR TITLE
Move Save prompt version button to a sticky footer

### DIFF
--- a/app/modules/prompts/components/promptEditor.tsx
+++ b/app/modules/prompts/components/promptEditor.tsx
@@ -109,17 +109,6 @@ export default function PromptEditor({
               Make production version
             </Button>
           )}
-          {!promptVersion.hasBeenSaved && (
-            <Button
-              variant="ghost"
-              className="hover:text-sandpiper-accent cursor-pointer"
-              disabled={!hasChanges || isLoading}
-              onClick={onSavePromptVersionClicked}
-            >
-              <Save />
-              Save prompt version
-            </Button>
-          )}
         </div>
       </div>
       <div className="grid gap-8 p-8">
@@ -197,6 +186,17 @@ export default function PromptEditor({
           />
         </div>
       </div>
+      {!promptVersion.hasBeenSaved && (
+        <div className="bg-background sticky bottom-0 z-10 flex justify-end rounded-b-md border-t px-8 py-4">
+          <Button
+            disabled={!hasChanges || isLoading}
+            onClick={onSavePromptVersionClicked}
+          >
+            <Save />
+            Save prompt version
+          </Button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Editing the prompt and schema happens at the bottom of the page, so saving no longer requires scrolling back to the header. Follows the sticky footer pattern used by evaluation and run set creation.

Fixes #2453