### PR TITLE
Name role as the required upload column instead of speaker

### DIFF
--- a/app/modules/files/__tests__/getInstructionsByFileType.test.ts
+++ b/app/modules/files/__tests__/getInstructionsByFileType.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import getInstructionsByFileType from "../helpers/getInstructionsByFileType";
+
+describe("getInstructionsByFileType", () => {
+  it.each(["CSV", "JSONL"] as const)(
+    "lists the canonical column names for %s uploads",
+    (fileType) => {
+      const { overview } = getInstructionsByFileType({ fileType });
+
+      for (const column of ["session_id", "sequence_id", "role", "content"]) {
+        expect(overview).toContain(`<code>${column}</code>`);
+      }
+      expect(overview).not.toContain("speaker");
+    },
+  );
+
+  it("returns empty instructions for file types without specific guidance", () => {
+    expect(getInstructionsByFileType({ fileType: "VTT" })).toEqual({
+      overview: "",
+      link: "",
+    });
+  });
+});

--- a/app/modules/files/helpers/getInstructionsByFileType.ts
+++ b/app/modules/files/helpers/getInstructionsByFileType.ts
@@ -8,12 +8,12 @@ export default function getInstructionsByFileType({
   switch (fileType) {
     case "CSV":
       return {
-        overview: `Upload a CSV file with the required <code>session_id</code>, <code>sequence_id</code>, <code>speaker</code>, and <code>content</code> columns.`,
+        overview: `Upload a CSV file with the required <code>session_id</code>, <code>sequence_id</code>, <code>role</code>, and <code>content</code> columns.`,
         link: "https://docs.google.com/document/d/16dSQp_MopRPLGYYgjgaWsXaJId3oufjvvgDqEWQfiDU",
       };
     case "JSONL":
       return {
-        overview: `Upload a JSONL file with the required <code>session_id</code>, <code>sequence_id</code>, <code>speaker</code>, and <code>content</code> columns.`,
+        overview: `Upload a JSONL file with the required <code>session_id</code>, <code>sequence_id</code>, <code>role</code>, and <code>content</code> fields.`,
         link: "https://docs.google.com/document/d/1x6kMZ2cpBuysJMlta7dVoRQ--G06PpWT26LenTex4R4",
       };
     default:


### PR DESCRIPTION
Upload instructions asked for a speaker column while the transcript schema, exports, and annotation templates all use role; speaker is only an accepted alias during attribute mapping. The instructions now name role and mention the speaker alias.

Fixes #2452