### PR TITLE
Remove MongoDB 5.0 compatibility from CI tests

### DIFF
--- a/.github/actions/start-mongodb/action.yml
+++ b/.github/actions/start-mongodb/action.yml
@@ -3,8 +3,8 @@ description: Start a MongoDB container with replica set support and create a CI 
 
 inputs:
   mongo-version:
-    description: MongoDB image tag (e.g. 5, 8)
-    default: "5"
+    description: MongoDB image tag (e.g. 8)
+    default: "8"
 
 runs:
   using: composite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,10 +58,6 @@ jobs:
     env:
       REDISMS_DISABLE_POSTINSTALL: 1
 
-    strategy:
-      matrix:
-        mongo-version: ["5", "8"]
-
     services:
       redis:
         image: redis:7
@@ -88,10 +84,8 @@ jobs:
         env:
           BULLMQ_PRO_TOKEN: ${{ secrets.BULLMQ_PRO_TOKEN }}
 
-      - name: Start MongoDB replica set (mongo:${{ matrix.mongo-version }})
+      - name: Start MongoDB replica set
         uses: ./.github/actions/start-mongodb
-        with:
-          mongo-version: ${{ matrix.mongo-version }}
 
       - name: Wait for services
         run: |


### PR DESCRIPTION
Drop the mongo 5/8 matrix from the test job and run against MongoDB 8 only. Default the start-mongodb action to mongo:8 so the e2e workflow moves off 5 as well. MongoDB 5.0 is end of life and local development already defaults to mongo:8.0.

Fixes #2457