### PR TITLE
Allow Cloudflare Insights beacon in CSP

### DIFF
--- a/app/modules/app/helpers/__tests__/buildContentSecurityPolicy.test.ts
+++ b/app/modules/app/helpers/__tests__/buildContentSecurityPolicy.test.ts
@@ -22,6 +22,7 @@ describe("buildContentSecurityPolicy", () => {
     expect(scriptSrc).toContain(`'nonce-${nonce}'`);
     expect(scriptSrc).toContain("'self'");
     expect(scriptSrc).toContain("https://www.googletagmanager.com");
+    expect(scriptSrc).toContain("https://static.cloudflareinsights.com");
     expect(scriptSrc).not.toContain("'unsafe-inline'");
   });
 
@@ -53,6 +54,7 @@ describe("buildContentSecurityPolicy", () => {
 
     expect(d["connect-src"]).toContain("'self'");
     expect(d["connect-src"]).toContain("https://www.google-analytics.com");
+    expect(d["connect-src"]).toContain("https://cloudflareinsights.com");
     expect(d["font-src"]).toContain("https://fonts.gstatic.com");
     expect(d["img-src"]).toContain("data:");
   });

--- a/app/modules/app/helpers/buildContentSecurityPolicy.ts
+++ b/app/modules/app/helpers/buildContentSecurityPolicy.ts
@@ -8,11 +8,17 @@ export default function buildContentSecurityPolicy(nonce: string): string {
       "'self'",
       `'nonce-${nonce}'`,
       "https://www.googletagmanager.com",
+      // Injected at the Cloudflare edge (Browser Insights), so it can't carry our nonce
+      "https://static.cloudflareinsights.com",
     ],
     "style-src": ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
     "font-src": ["'self'", "https://fonts.gstatic.com"],
     "img-src": ["'self'", "data:"],
-    "connect-src": ["'self'", "https://www.google-analytics.com"],
+    "connect-src": [
+      "'self'",
+      "https://www.google-analytics.com",
+      "https://cloudflareinsights.com",
+    ],
     "frame-src": ["'self'"],
     "frame-ancestors": ["'self'"],
     "form-action": ["'self'"],


### PR DESCRIPTION
Production sits behind Cloudflare with Browser Insights enabled. The beacon script is injected at the edge after SSR, so it cannot carry the per-request nonce and shows up in violation reports. Allow the script host in script-src and the RUM endpoint in connect-src so enforcement does not block it.

Fixes #2459