### PR TITLE
Add public privacy policy page to the homepage

### DIFF
--- a/app/modules/app/components/sidebarHelpDropdown.tsx
+++ b/app/modules/app/components/sidebarHelpDropdown.tsx
@@ -8,12 +8,10 @@ import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { SidebarMenuButton } from "@/components/ui/sidebar";
 import { CircleHelp } from "lucide-react";
 import { useState } from "react";
-import FullTermsDialog from "~/modules/authentication/components/fullTermsDialog";
 import SupportArticlesContainer from "~/modules/support/containers/supportArticles.container";
 
 export default function SideBarHelpDropdown() {
   const [docsOpen, setDocsOpen] = useState(false);
-  const [termsOpen, setTermsOpen] = useState(false);
 
   return (
     <>
@@ -60,8 +58,10 @@ export default function SideBarHelpDropdown() {
               View Existing Issues
             </a>
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => setTermsOpen(true)}>
-            Terms of Use & Privacy Policy
+          <DropdownMenuItem asChild>
+            <a href="/privacy" target="_blank" rel="noopener noreferrer">
+              Terms of Use & Privacy Policy
+            </a>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -71,8 +71,6 @@ export default function SideBarHelpDropdown() {
           <SupportArticlesContainer />
         </SheetContent>
       </Sheet>
-
-      <FullTermsDialog open={termsOpen} onOpenChange={setTermsOpen} />
     </>
   );
 }

--- a/app/modules/authentication/__tests__/splashFooter.test.tsx
+++ b/app/modules/authentication/__tests__/splashFooter.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it } from "vitest";
+import { Footer } from "../components/splash/footer";
+
+function renderFooter(sectionHrefPrefix: string) {
+  return render(
+    <MemoryRouter>
+      <Footer sectionHrefPrefix={sectionHrefPrefix} />
+    </MemoryRouter>,
+  );
+}
+
+const hrefOf = (name: string) =>
+  screen.getByRole("link", { name }).getAttribute("href");
+
+// This repo does not enable vitest globals, so RTL's automatic cleanup
+// between tests never registers. Without this, renders accumulate in the DOM.
+afterEach(cleanup);
+
+describe("splash Footer", () => {
+  it("links to the public privacy policy page", () => {
+    renderFooter("");
+
+    expect(hrefOf("Privacy Policy")).toBe("/privacy");
+  });
+
+  it("keeps section links as in-page anchors on the splash", () => {
+    renderFooter("");
+
+    expect(hrefOf("Home")).toBe("#hero");
+    expect(hrefOf("Features")).toBe("#features");
+    expect(hrefOf("How It Works")).toBe("#how-it-works");
+    expect(hrefOf("About")).toBe("#about");
+  });
+
+  // Regression: the footer is reused on /privacy, where none of the splash
+  // sections exist. Bare "#features" anchors were dead links there, so the
+  // prefix has to send them home first.
+  it("sends section links home first when rendered off the splash", () => {
+    renderFooter("/");
+
+    expect(hrefOf("Home")).toBe("/#hero");
+    expect(hrefOf("Features")).toBe("/#features");
+    expect(hrefOf("How It Works")).toBe("/#how-it-works");
+    expect(hrefOf("About")).toBe("/#about");
+  });
+});

--- a/app/modules/authentication/components/splash.tsx
+++ b/app/modules/authentication/components/splash.tsx
@@ -2,6 +2,7 @@ import { About } from "./splash/about";
 import { AnnouncementBanner } from "./splash/announcementBanner";
 import { Benefits } from "./splash/benefits";
 import { CTASection } from "./splash/ctaSection";
+import { DataPrivacy } from "./splash/dataPrivacy";
 import { Features } from "./splash/features";
 import { Footer } from "./splash/footer";
 import { Hero } from "./splash/hero";
@@ -30,8 +31,9 @@ export default function Splash() {
       <Research />
       <About />
       <Impact />
+      <DataPrivacy />
       <CTASection />
-      <Footer />
+      <Footer sectionHrefPrefix="" />
     </div>
   );
 }

--- a/app/modules/authentication/components/splash/dataPrivacy.tsx
+++ b/app/modules/authentication/components/splash/dataPrivacy.tsx
@@ -1,0 +1,101 @@
+import {
+  EyeOffIcon,
+  LockIcon,
+  ShieldCheckIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { Link } from "react-router";
+
+export function DataPrivacy() {
+  const highlights = [
+    {
+      icon: <EyeOffIcon size={22} />,
+      color: "#367181",
+      title: "Confidential by Default",
+      description:
+        "Not sold, not shared for advertising, and never accessed for internal analyses without your explicit consent.",
+    },
+    {
+      icon: <ShieldCheckIcon size={22} />,
+      color: "#D4A843",
+      title: "Cornell Secure AI Gateway",
+      description:
+        "Annotation calls run through Cornell's university-managed LiteLLM gateway. Never stored by model providers, never used to train AI systems.",
+    },
+    {
+      icon: <LockIcon size={22} />,
+      color: "#D8654F",
+      title: "Encrypted at Rest and in Transit",
+      description:
+        "AES-256 encryption, on AWS infrastructure in the United States.",
+    },
+    {
+      icon: <Trash2Icon size={22} />,
+      color: "#A64B2A",
+      title: "Yours to Delete",
+      description:
+        "Delete your data at any time from project settings. Removal from active servers completes within 30 days.",
+    },
+  ];
+
+  return (
+    <section
+      id="privacy"
+      className="relative overflow-hidden py-22 text-white"
+      style={{
+        background:
+          "linear-gradient(135deg, #2C241B 0%, #322b22 45%, #2a3530 100%)",
+      }}
+    >
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(ellipse 600px 400px at 15% 25%, rgba(54,113,129,0.1), transparent), radial-gradient(ellipse 500px 400px at 85% 75%, rgba(212,168,67,0.07), transparent)",
+        }}
+      />
+      <div className="relative z-10 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="mb-12 text-center">
+          <div className="mb-2 text-[0.72rem] font-bold tracking-[0.14em] text-[#D4A843] uppercase">
+            Data &amp; Privacy
+          </div>
+          <h2 className="font-display text-section-heading mb-4 leading-[1.15] font-bold tracking-[-0.01em]">
+            Built for Research Data
+          </h2>
+          <p className="mx-auto max-w-[620px] text-[1.05rem] leading-[1.7] text-white/50">
+            Sandpiper is hosted by Cornell University, and every commitment
+            below is written into the policy itself.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+          {highlights.map((highlight) => (
+            <div
+              key={highlight.title}
+              className="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-white/4 p-8 backdrop-blur-[12px] transition-all hover:-translate-y-1 hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.08)]"
+            >
+              <div className="mb-4" style={{ color: highlight.color }}>
+                {highlight.icon}
+              </div>
+              <div className="mb-2 text-[0.95rem] font-semibold">
+                {highlight.title}
+              </div>
+              <div className="text-[0.85rem] leading-relaxed text-white/55">
+                {highlight.description}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-12 text-center">
+          <Link
+            to="/privacy"
+            className="inline-flex items-center gap-2 rounded-[0.625rem] border-2 border-[rgba(255,255,255,0.5)] bg-transparent px-7 py-3 font-semibold text-white no-underline transition-all hover:border-white hover:bg-[rgba(255,255,255,0.12)]"
+          >
+            Read the full Terms of Use &amp; Privacy Policy &rarr;
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/modules/authentication/components/splash/footer.tsx
+++ b/app/modules/authentication/components/splash/footer.tsx
@@ -1,6 +1,9 @@
+import { Link } from "react-router";
 import sandpiperLogo from "~/assets/sandpiper-logo.svg";
 
-export function Footer() {
+// Section links are in-page anchors on the splash, but must navigate home
+// first from any other page. Pass "" on the splash and "/" elsewhere.
+export function Footer({ sectionHrefPrefix }: { sectionHrefPrefix: string }) {
   return (
     <footer className="bg-[#2C241B] py-8 text-[0.82rem] text-[rgba(255,255,255,0.5)]">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -23,29 +26,35 @@ export function Footer() {
           </div>
           <div className="flex gap-6">
             <a
-              href="#hero"
+              href={`${sectionHrefPrefix}#hero`}
               className="text-[rgba(255,255,255,0.55)] no-underline transition-colors hover:text-[#D4A843]"
             >
               Home
             </a>
             <a
-              href="#features"
+              href={`${sectionHrefPrefix}#features`}
               className="text-[rgba(255,255,255,0.55)] no-underline transition-colors hover:text-[#D4A843]"
             >
               Features
             </a>
             <a
-              href="#how-it-works"
+              href={`${sectionHrefPrefix}#how-it-works`}
               className="text-[rgba(255,255,255,0.55)] no-underline transition-colors hover:text-[#D4A843]"
             >
               How It Works
             </a>
             <a
-              href="#about"
+              href={`${sectionHrefPrefix}#about`}
               className="text-[rgba(255,255,255,0.55)] no-underline transition-colors hover:text-[#D4A843]"
             >
               About
             </a>
+            <Link
+              to="/privacy"
+              className="text-[rgba(255,255,255,0.55)] no-underline transition-colors hover:text-[#D4A843]"
+            >
+              Privacy Policy
+            </Link>
           </div>
           <div>
             <span>Built by </span>

--- a/app/modules/authentication/components/splash/navbar.tsx
+++ b/app/modules/authentication/components/splash/navbar.tsx
@@ -14,6 +14,7 @@ export function Navbar() {
     { label: "Evaluation", href: "#metrics" },
     { label: "Research", href: "#research" },
     { label: "About", href: "#about" },
+    { label: "Privacy", href: "#privacy" },
   ];
 
   return (

--- a/app/modules/authentication/components/splash/policyHeader.tsx
+++ b/app/modules/authentication/components/splash/policyHeader.tsx
@@ -1,0 +1,44 @@
+import { ArrowLeftIcon } from "lucide-react";
+import { Link } from "react-router";
+import sandpiperLogo from "~/assets/sandpiper-logo.svg";
+
+// The marketing Navbar links to on-page sections (#features, #about, ...) that
+// only exist on the splash. Policy pages get this slim header instead so none
+// of those anchors can go dead.
+export function PolicyHeader() {
+  return (
+    <header className="border-b border-[rgba(230,226,214,0.6)] bg-[#f9f7f1]/82 backdrop-blur-[20px]">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex h-16 items-center justify-between gap-4">
+          <Link
+            to="/"
+            className="font-display flex items-center gap-2 text-[1.3rem] font-bold text-[#2C241B] no-underline"
+          >
+            <img
+              src={sandpiperLogo}
+              alt="Sandpiper"
+              className="h-[50px] w-[50px]"
+            />
+            Sandpiper
+          </Link>
+
+          <div className="flex items-center gap-4 sm:gap-6">
+            <Link
+              to="/"
+              className="inline-flex items-center gap-1.5 text-[0.88rem] font-medium text-[#5D534A] no-underline transition-colors hover:text-[#B31B1B]"
+            >
+              <ArrowLeftIcon size={14} />
+              Back to home
+            </Link>
+            <Link
+              to="/signup"
+              className="rounded-[0.625rem] bg-[#367181] px-4 py-2 text-sm font-semibold text-white no-underline transition-all hover:bg-[#2a5a68]"
+            >
+              Open App
+            </Link>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/app/modules/authentication/components/splash/privacyPolicy.tsx
+++ b/app/modules/authentication/components/splash/privacyPolicy.tsx
@@ -1,12 +1,3 @@
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import {
   FileTextIcon,
   LockIcon,
@@ -14,38 +5,42 @@ import {
   XCircleIcon,
 } from "lucide-react";
 
-interface FullTermsDialogProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}
-
-export default function FullTermsDialog({
-  open,
-  onOpenChange,
-}: FullTermsDialogProps) {
+export function PrivacyPolicy() {
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-2xl">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <FileTextIcon className="size-5" />
-            Sandpiper Terms of Use and Privacy Policy
-          </DialogTitle>
-          <DialogDescription>Hosted by Cornell University</DialogDescription>
-        </DialogHeader>
+    <section
+      id="privacy-policy"
+      className="pt-16 pb-22"
+      style={{
+        background: "linear-gradient(170deg, #F9F7F1 0%, #f0ece0 100%)",
+      }}
+    >
+      <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+        <div className="mb-2 flex items-center gap-2 text-[0.72rem] font-bold tracking-[0.14em] text-[#A64B2A] uppercase">
+          <FileTextIcon size={14} />
+          Terms &amp; Privacy
+        </div>
+        <h1 className="font-display text-section-heading mb-3 leading-[1.15] font-bold tracking-[-0.01em] text-[#2C241B]">
+          Terms of Use and Privacy Policy
+        </h1>
+        <p className="mb-10 text-[1.05rem] text-[#5D534A]">
+          Hosted by Cornell University
+        </p>
 
-        <div className="text-body-lg space-y-4 overflow-y-auto">
-          <p className="text-muted-foreground leading-relaxed">
+        <div className="space-y-4">
+          <p className="text-base leading-[1.8] text-[#5D534A]">
             This Contract governing Users&rsquo; Terms of Use (TOU or Agreement)
             constitutes a legal and binding contract between you and{" "}
-            <strong className="text-foreground">Cornell University</strong>{" "}
+            <strong className="font-semibold text-[#2C241B]">
+              Cornell University
+            </strong>{" "}
             (hereinafter &ldquo;Cornell&rdquo;), containing the terms and
             conditions for licensed access to the information and use of the{" "}
-            <strong className="text-foreground">Sandpiper</strong> web
-            application developed by the National Tutoring Observatory (NTO).
+            <strong className="font-semibold text-[#2C241B]">Sandpiper</strong>{" "}
+            web application developed by the National Tutoring Observatory
+            (NTO).
           </p>
 
-          <div className="bg-destructive/5 border-destructive text-caption rounded-r-md border-l-[3px] px-3 py-2 font-semibold text-red-700 dark:text-red-400">
+          <div className="rounded-r-md border-l-[3px] border-[#B31B1B] bg-[rgba(179,27,27,0.05)] px-4 py-3 text-[0.85rem] leading-[1.7] font-semibold text-[#8B1515]">
             Access to Sandpiper is offered to registered and authorized users.
             Use of this licensed content requires that you carefully read and
             agree in full with all of the terms and conditions of this agreement
@@ -53,7 +48,7 @@ export default function FullTermsDialog({
           </div>
 
           <SectionHeading num={1}>License Grant and Ownership</SectionHeading>
-          <p className="text-muted-foreground leading-relaxed">
+          <p className="text-base leading-[1.8] text-[#5D534A]">
             Cornell hereby grants to you a limited, non-exclusive,
             non-sublicensable license to access Sandpiper solely for research
             and educational purposes. Cornell is and remains the owner of all
@@ -66,7 +61,7 @@ export default function FullTermsDialog({
           <SectionHeading num={2}>
             User Information and Authentication
           </SectionHeading>
-          <p className="text-muted-foreground leading-relaxed">
+          <p className="text-base leading-[1.8] text-[#5D534A]">
             When you log in via GitHub, we receive your GitHub username, display
             name, and GitHub user ID. This information is used solely to
             authenticate you and manage your access to the application. You
@@ -77,27 +72,27 @@ export default function FullTermsDialog({
           <SectionHeading num={3}>
             Data Ingestion, Storage, and Privacy
           </SectionHeading>
-          <p className="text-muted-foreground leading-relaxed">
+          <p className="text-base leading-[1.8] text-[#5D534A]">
             Your uploaded data, including tutoring transcripts and session
             interactions, are treated as confidential research data. By
             uploading data, you explicitly acknowledge the following processing
             flows:
           </p>
 
-          <SubHeading icon={<LockIcon className="size-3.5" />}>
+          <SubHeading icon={<LockIcon className="size-4" />}>
             Storage &amp; Encryption
           </SubHeading>
-          <p className="text-muted-foreground leading-relaxed">
+          <p className="text-base leading-[1.8] text-[#5D534A]">
             Your uploaded data is encrypted at rest and in transit using
             industry-standard AES-256 encryption. The application and all data
             are hosted securely on Amazon Web Services (AWS) infrastructure in
             the United States.
           </p>
 
-          <SubHeading icon={<ShieldCheckIcon className="size-3.5" />}>
+          <SubHeading icon={<ShieldCheckIcon className="size-4" />}>
             Cornell Secure AI Gateway
           </SubHeading>
-          <p className="text-muted-foreground leading-relaxed">
+          <p className="text-base leading-[1.8] text-[#5D534A]">
             All Large Language Model (LLM) API calls for transcript annotation
             are routed through Cornell University&rsquo;s AI Gateway, a secure,
             university-managed proxy operated by the AI Innovation Hub. The
@@ -107,12 +102,10 @@ export default function FullTermsDialog({
             services outside of this controlled environment.
           </p>
 
-          <SubHeading
-            icon={<XCircleIcon className="text-destructive size-3.5" />}
-          >
+          <SubHeading icon={<XCircleIcon className="size-4" />}>
             Prohibited Uses of Data
           </SubHeading>
-          <p className="text-muted-foreground leading-relaxed">
+          <p className="text-base leading-[1.8] text-[#5D534A]">
             We will never use your uploaded data to train, fine-tune, evaluate,
             or improve foundation models, speech models, tutoring models,
             biometric systems, or other general-purpose AI systems. We do not
@@ -124,7 +117,7 @@ export default function FullTermsDialog({
           <SectionHeading num={4}>
             GDPR Compliance and Rights for EU Users
           </SectionHeading>
-          <p className="text-muted-foreground leading-relaxed">
+          <p className="text-base leading-[1.8] text-[#5D534A]">
             In compliance with the General Data Protection Regulation (GDPR),
             users residing within the European Economic Area (EEA) possess
             specific rights regarding their personal data and any Personally
@@ -132,16 +125,16 @@ export default function FullTermsDialog({
             EU are permitted to use the platform under the condition that they
             understand these rights:
           </p>
-          <ul className="text-muted-foreground list-disc space-y-1 pl-5 leading-relaxed">
+          <ul className="list-disc space-y-2 pl-5 text-base leading-[1.8] text-[#5D534A]">
             <li>
-              <strong className="text-foreground">
+              <strong className="font-semibold text-[#2C241B]">
                 Right to Access and Portability:
               </strong>{" "}
               You have the right to request access to the personal data we hold
               about you and receive it in a structured format.
             </li>
             <li>
-              <strong className="text-foreground">
+              <strong className="font-semibold text-[#2C241B]">
                 Right to Erasure (Right to be Forgotten):
               </strong>{" "}
               You may delete your data at any time from your project settings.
@@ -150,7 +143,7 @@ export default function FullTermsDialog({
               You may also request the complete deletion of your user account.
             </li>
             <li>
-              <strong className="text-foreground">
+              <strong className="font-semibold text-[#2C241B]">
                 Right to Withdraw Consent:
               </strong>{" "}
               You can withdraw consent for processing at any time by ceasing use
@@ -158,7 +151,7 @@ export default function FullTermsDialog({
               account data.
             </li>
           </ul>
-          <p className="text-muted-foreground leading-relaxed">
+          <p className="text-base leading-[1.8] text-[#5D534A]">
             Sandpiper is designed with FERPA- and COPPA-eligible workflows in
             mind for researchers working with educational data. Sandpiper
             strictly operates as a data processor for uploaded tutoring
@@ -168,7 +161,7 @@ export default function FullTermsDialog({
           </p>
 
           <SectionHeading num={5}>Analytics</SectionHeading>
-          <p className="text-muted-foreground leading-relaxed">
+          <p className="text-base leading-[1.8] text-[#5D534A]">
             We use Google Analytics 4 to collect anonymized usage data (e.g.,
             pages visited, performance metrics, device types). Google Analytics
             uses cookies to distinguish unique users and sessions. IP addresses
@@ -181,7 +174,7 @@ export default function FullTermsDialog({
           <SectionHeading num={6}>
             No Warranty and Limitation of Liability
           </SectionHeading>
-          <p className="text-muted-foreground text-caption tracking-wide uppercase opacity-85">
+          <p className="text-[0.8rem] leading-[1.7] tracking-wide text-[#5D534A] uppercase">
             The tool is provided &ldquo;as is&rdquo; without warranty of any
             kind, express or implied. Cornell and FreshCognate will not be
             responsible to you or your entity for any consequences, foreseeable
@@ -193,7 +186,7 @@ export default function FullTermsDialog({
           <SectionHeading num={7}>
             Governing Law and Jurisdiction
           </SectionHeading>
-          <p className="text-muted-foreground leading-relaxed">
+          <p className="text-base leading-[1.8] text-[#5D534A]">
             This License shall be governed by and construed in accordance with
             the laws of the United States and the State of New York. Any claim
             arising from or related to this Agreement must be brought in state
@@ -202,29 +195,25 @@ export default function FullTermsDialog({
           </p>
 
           <SectionHeading num={8}>Contact Information</SectionHeading>
-          <p className="text-muted-foreground leading-relaxed">
+          <p className="text-base leading-[1.8] text-[#5D534A]">
             If you have questions about this privacy policy or our data
             practices, please contact us through the National Tutoring
             Observatory or Cornell&rsquo;s privacy contacts. We will publish on
             our website any changes we make to this Privacy Statement.
           </p>
 
-          <div className="text-muted-foreground border-border text-caption border-t pt-3">
+          <div className="mt-8 border-t border-[#E6E2D6] pt-5 text-[0.9rem] text-[#5D534A]">
             Questions? Reach us at{" "}
             <a
               href="mailto:CIS-NTO-PARTNERSHIPS-L@list.cornell.edu"
-              className="text-primary font-semibold"
+              className="font-semibold text-[#A64B2A] underline hover:text-[#8B3D21]"
             >
               CIS-NTO-PARTNERSHIPS-L@list.cornell.edu
             </a>
           </div>
         </div>
-
-        <DialogFooter>
-          <Button onClick={() => onOpenChange(false)}>Close</Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      </div>
+    </section>
   );
 }
 
@@ -236,12 +225,12 @@ function SectionHeading({
   children: React.ReactNode;
 }) {
   return (
-    <h3 className="text-heading flex items-center gap-2 pt-2 font-semibold">
-      <span className="bg-primary text-caption flex size-5 shrink-0 items-center justify-center rounded-full font-bold text-white">
+    <h2 className="font-display flex items-center gap-3 pt-6 text-[1.15rem] font-bold text-[#2C241B]">
+      <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-[#367181] text-[0.75rem] font-bold text-white">
         {num}
       </span>
       {children}
-    </h3>
+    </h2>
   );
 }
 
@@ -253,9 +242,9 @@ function SubHeading({
   children: React.ReactNode;
 }) {
   return (
-    <h4 className="text-foreground text-heading flex items-center gap-1.5 font-semibold">
-      <span className="text-primary">{icon}</span>
+    <h3 className="font-display flex items-center gap-2 pt-2 text-[1rem] font-semibold text-[#2C241B]">
+      <span className="text-[#367181]">{icon}</span>
       {children}
-    </h4>
+    </h3>
   );
 }

--- a/app/modules/authentication/components/termsAcceptance.tsx
+++ b/app/modules/authentication/components/termsAcceptance.tsx
@@ -9,7 +9,6 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import sandpiperLogo from "~/assets/sandpiper-logo.svg";
-import FullTermsDialog from "./fullTermsDialog";
 
 interface TermsAcceptanceProps {
   isSubmitting: boolean;
@@ -21,7 +20,6 @@ export default function TermsAcceptance({
   onAccept,
 }: TermsAcceptanceProps) {
   const [accepted, setAccepted] = useState(false);
-  const [termsOpen, setTermsOpen] = useState(false);
 
   return (
     <div className="bg-muted flex min-h-screen w-screen items-center justify-center">
@@ -76,13 +74,14 @@ export default function TermsAcceptance({
           >
             I have read and agree to the&nbsp;
           </Label>
-          <button
-            type="button"
+          <a
+            href="/privacy"
+            target="_blank"
+            rel="noreferrer"
             className="text-primary text-body -ml-1.5 font-semibold hover:underline"
-            onClick={() => setTermsOpen(true)}
           >
             Terms&nbsp;of&nbsp;Use and Privacy&nbsp;Policy
-          </button>
+          </a>
         </div>
 
         <Button
@@ -93,8 +92,6 @@ export default function TermsAcceptance({
           {isSubmitting ? "Saving..." : "Continue \u2192"}
         </Button>
       </div>
-
-      <FullTermsDialog open={termsOpen} onOpenChange={setTermsOpen} />
     </div>
   );
 }

--- a/app/modules/authentication/containers/authentication.container.tsx
+++ b/app/modules/authentication/containers/authentication.container.tsx
@@ -28,6 +28,7 @@ export default function AuthenticationContainer({
   const isJoinRoute = useMatch("/join/:slug");
   const isSignupRoute = useMatch("/signup");
   const isOnboardingRoute = useMatch("/onboarding");
+  const isPrivacyRoute = useMatch("/privacy");
   const lastFetchRef = useRef<number>(0);
   const MIN_FETCH_INTERVAL = 1 * 60 * 1000;
   const prevAuthRef = useRef<User | null>(null);
@@ -67,7 +68,13 @@ export default function AuthenticationContainer({
     }
   }, [location.pathname]);
 
-  if (isInviteRoute || isJoinRoute || isSignupRoute || isOnboardingRoute) {
+  if (
+    isInviteRoute ||
+    isJoinRoute ||
+    isSignupRoute ||
+    isOnboardingRoute ||
+    isPrivacyRoute
+  ) {
     return <Outlet />;
   }
 

--- a/app/modules/authentication/containers/privacy.route.tsx
+++ b/app/modules/authentication/containers/privacy.route.tsx
@@ -1,0 +1,25 @@
+import { AnnouncementBanner } from "../components/splash/announcementBanner";
+import { Footer } from "../components/splash/footer";
+import { PolicyHeader } from "../components/splash/policyHeader";
+import { PrivacyPolicy } from "../components/splash/privacyPolicy";
+
+export const meta = () => [
+  { title: "Terms of Use & Privacy Policy - Sandpiper" },
+  {
+    name: "description",
+    content:
+      "How Sandpiper handles tutoring transcripts and research data: encryption, Cornell's Secure AI Gateway, GDPR rights, and data deletion.",
+  },
+];
+
+export default function PrivacyRoute() {
+  return (
+    // pt clears the fixed AnnouncementBanner, matching the offset Navbar uses.
+    <div className="min-h-screen pt-[32px] font-sans text-[#2C241B]">
+      <AnnouncementBanner />
+      <PolicyHeader />
+      <PrivacyPolicy />
+      <Footer sectionHrefPrefix="/" />
+    </div>
+  );
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -43,6 +43,7 @@ export const meta: Route.MetaFunction = () => [{ title: "Sandpiper - NTO" }];
 
 const TERMS_EXEMPT_PATHS = [
   "/onboarding",
+  "/privacy",
   "/auth/",
   "/api/authentication",
   "/api/webhooks/",

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -168,6 +168,7 @@ export default [
   ...prefix("join", [
     route(":slug", "modules/teams/containers/join.route.tsx", { id: "join" }),
   ]),
+  route("privacy", "modules/authentication/containers/privacy.route.tsx"),
   route("signup", "modules/authentication/containers/signup.route.tsx"),
   route("onboarding", "modules/authentication/containers/onboarding.route.tsx"),
   route("api", "modules/app/containers/api.route.tsx"),

--- a/e2e/privacy.spec.ts
+++ b/e2e/privacy.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+
+// The whole point of issue #2468: researchers and IRBs must be able to read
+// how data is handled WITHOUT signing in. These run with no session, so they
+// would catch either gate (root.tsx terms redirect, or the
+// authentication.container redirect to /signup) swallowing the page.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe("public privacy policy", () => {
+  test("serves the policy to visitors with no account", async ({ page }) => {
+    const response = await page.goto("/privacy");
+
+    expect(response?.status()).toBe(200);
+    // Not bounced to /signup or /onboarding.
+    await expect(page).toHaveURL(/\/privacy$/);
+    await expect(
+      page.getByRole("heading", { name: "Terms of Use and Privacy Policy" }),
+    ).toBeVisible();
+  });
+
+  test("covers the data handling questions an IRB would ask", async ({
+    page,
+  }) => {
+    await page.goto("/privacy");
+
+    await expect(page.getByText("AES-256", { exact: false })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Cornell Secure AI Gateway" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /GDPR Compliance/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /CIS-NTO-PARTNERSHIPS-L/ }),
+    ).toBeVisible();
+  });
+
+  test("is reachable from the logged-out homepage", async ({ page }) => {
+    // Renders the entire splash, which is a cold compile against a dev server.
+    test.slow();
+    await page.goto("/");
+
+    // The splash renders client-side once the auth check resolves.
+    const section = page.locator("#privacy");
+    await section.scrollIntoViewIfNeeded();
+    await expect(
+      section.getByRole("heading", { name: "Built for Research Data" }),
+    ).toBeVisible();
+
+    await section
+      .getByRole("link", { name: /Read the full Terms of Use/ })
+      .click();
+
+    await expect(page).toHaveURL(/\/privacy$/);
+    await expect(
+      page.getByRole("heading", { name: "Terms of Use and Privacy Policy" }),
+    ).toBeVisible();
+  });
+
+  test("offers a way back to the site", async ({ page }) => {
+    await page.goto("/privacy");
+
+    await page.getByRole("link", { name: "Back to home" }).click();
+
+    await expect(page).toHaveURL("http://localhost:5173/");
+  });
+});


### PR DESCRIPTION
Fixes #2468

## Problem

The terms and privacy text lived only inside `fullTermsDialog.tsx`, reachable from the onboarding consent gate and the in-app sidebar help dropdown. Anyone evaluating Sandpiper had to sign in with GitHub before they could read how tutoring data is handled — exactly the wrong order for a researcher or an IRB deciding whether to create an account.

## Changes

**A public `/privacy` route** carrying the full Terms of Use and Privacy Policy, styled as part of the public site rather than the app.

**A "Data & Privacy" section on the splash**, between Impact and the CTA, summarising the four points people actually ask about — AES-256 encryption, the Cornell Secure AI Gateway, the no-training commitment, and deletion rights — with a link to the full page. Linked from the splash navbar (`#privacy`) and the footer.

**The dialog is gone.** Both former call sites now link to `/privacy` in a new tab. New tab rather than same tab because the consent checkbox in `termsAcceptance.tsx` holds `accepted` in local state, so navigating away would silently discard the tick.

## Notes for review

Two gates had to let the page through, and either one would have reproduced the original bug:

- `app/root.tsx` redirects users who have not accepted the terms to `/onboarding`. `/privacy` is now exempt, so someone on the consent gate can read what they are agreeing to. This is the only reason root changes at all — a logged-out visitor never hits that branch, since it requires a session.
- `authentication.container.tsx` sends any non-passthrough route to `/signup` when there is no session. `/privacy` joins the passthrough list, which also means it server-renders rather than flashing a spinner.

Policy pages get a slim header (`policyHeader.tsx`) instead of the marketing navbar. The navbar's links are all on-page anchors (`#features`, `#about`, …) that would be dead on a page without those sections. For the same reason the shared `Footer` now takes a `sectionHrefPrefix` — `""` on the splash to keep in-page smooth scrolling, `"/"` elsewhere so its four section links navigate home first.

`TERMS_EXEMPT_PATHS` matches with `startsWith`, so the `/privacy` entry would also prefix-match a future route like `/privacy-settings` and let it skip the terms gate. No such route exists, and tightening the matching was deliberately left out of this PR to keep `root.tsx` to a one-line diff.

## Verification

- `yarn typecheck`, `yarn app:build` — pass
- `yarn test` — 1374 tests across 170 files pass
- `yarn lint` — no errors or warnings in the changed files
- `e2e/privacy.spec.ts` — 6 new Playwright tests pass, run with no session so they would catch either gate swallowing the page: the policy is served to visitors with no account and stays on `/privacy`, the data-handling sections an IRB would look for are present, the splash section links through, and "Back to home" returns to the site
- `splashFooter.test.tsx` — covers the dead-anchor regression in both prefix modes
