### PR TITLE
Make LLM pricing failures loud instead of unbilled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,6 +340,8 @@ A model's `code` is a **stored identity**, not just the name sent to the gateway
 - The gateway renamed its models to provider-native naming and keeps the old names as hidden aliases, so shipped codes keep working. Only **new** models get canonical names. The config therefore mixes both conventions on purpose — do not tidy it up.
 - Retire a model with `"deprecated": true`, never by deleting the entry. Deprecated models stay out of the pickers but keep resolving for pricing and display, which is why `getModelPricing` passes `includeDeprecated`.
 - `defaultModel` must point at a non-deprecated model — session uploads call it with no fallback, so a retired default breaks uploads outright. `modelAvailability.test.ts` guards this and checks every selectable code against a snapshot of the gateway listing; refresh instructions are in `gatewayModels.fixture.json`.
+- **Never write a model code in application source.** A call that needs a specific model declares a role in `taskModels` and resolves it with `getTaskModelCode(role)` (add the role to the `TaskModelRole` union). Keeping the config as the only enumeration of codes is what lets `modelAvailability.test.ts` and `modelRegistry.test.ts` cover every code the app can send — a literal in a service is invisible to both.
+- A pricing failure propagates out of `LLM.createChat` rather than being warned and swallowed. `calculateLlmCost` sits outside the `try` in `writeCostRecord` on purpose: the tokens are already spent at the provider by that point, so swallowing it bills the team nothing and leaves only a log line. Callers turn the throw into an `ERRORED` run session or a 500.
 
 ## Path Aliases
 

--- a/app/config/ai_gateway.json
+++ b/app/config/ai_gateway.json
@@ -1,5 +1,10 @@
 {
   "defaultModel": "nto.gemini-3.1-flash-lite",
+  "taskModels": {
+    "promptAlignment": "anthropic.claude-4.6-sonnet",
+    "promptSuggestions": "anthropic.claude-4.6-sonnet",
+    "codebookImport": "anthropic.claude-4.6-opus"
+  },
   "providers": [
     {
       "name": "Google",

--- a/app/modules/codebooks/services/createPromptFromCodebook.server.ts
+++ b/app/modules/codebooks/services/createPromptFromCodebook.server.ts
@@ -1,6 +1,7 @@
 import type { AnnotationTypeOptions } from "~/modules/annotations/helpers/annotationTypes";
 import handleLLMError from "~/modules/llm/helpers/handleLLMError";
 import LLM from "~/modules/llm/llm";
+import { getTaskModelCode } from "~/modules/llm/modelRegistry";
 import { PromptService } from "~/modules/prompts/prompt";
 import { PromptVersionService } from "~/modules/prompts/promptVersion";
 import { CodebookService } from "../codebook";
@@ -72,7 +73,7 @@ export default async function createPromptFromCodebook({
     };
 
     const llm = new LLM({
-      model: "anthropic.claude-4.6-opus",
+      model: getTaskModelCode("codebookImport"),
       team: teamId,
       userId,
       source: "codebook-prompt-generation",

--- a/app/modules/llm/__tests__/llm.test.ts
+++ b/app/modules/llm/__tests__/llm.test.ts
@@ -26,9 +26,12 @@ vi.mock("../helpers/getLLM", () => ({
   }),
 }));
 
+const defaultCalculateLlmCost = ({ inputTokens, outputTokens }: any) =>
+  (inputTokens + outputTokens) * 0.00001;
+const mockCalculateLlmCost = vi.fn(defaultCalculateLlmCost);
+
 vi.mock("../helpers/calculateLlmCost", () => ({
-  default: ({ inputTokens, outputTokens }: any) =>
-    (inputTokens + outputTokens) * 0.00001,
+  default: (input: any) => mockCalculateLlmCost(input),
 }));
 
 vi.mock("~/modules/billing/services/applyBillingDebit.server", () => ({
@@ -51,6 +54,7 @@ beforeEach(async () => {
   vi.resetModules();
   mockCreateChat.mockReset();
   mockCostCreate.mockReset().mockResolvedValue({});
+  mockCalculateLlmCost.mockReset().mockImplementation(defaultCalculateLlmCost);
   const mod = await import("../llm");
   LLM = mod.default;
 });
@@ -234,6 +238,30 @@ describe("LLM", () => {
       llm.addUserMessage("test", {});
 
       await expect(llm.createChat()).resolves.toEqual({ result: "ok" });
+    });
+
+    it("propagates pricing failures instead of billing nothing", async () => {
+      mockCalculateLlmCost.mockImplementationOnce(() => {
+        throw new Error("No pricing found for model: test-model");
+      });
+      mockCreateChat.mockResolvedValueOnce({
+        content: { result: "ok" },
+        usage: mockUsage,
+      });
+
+      const llm = new LLM({
+        source: SOURCE,
+        model: MODEL,
+        userId: "user-123",
+        billingEventId: makeBillingEventId("pricing-failure"),
+        team: "team-1",
+      });
+      llm.addUserMessage("test", {});
+
+      await expect(llm.createChat()).rejects.toThrow(
+        "No pricing found for model: test-model",
+      );
+      expect(mockCostCreate).not.toHaveBeenCalled();
     });
   });
 

--- a/app/modules/llm/__tests__/modelAvailability.test.ts
+++ b/app/modules/llm/__tests__/modelAvailability.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import aiGatewayConfig from "~/config/ai_gateway.json";
 import { getAvailableModels, getDefaultModelCode } from "../modelRegistry";
 import gatewayModels from "./gatewayModels.fixture.json";
 
@@ -43,6 +44,23 @@ describe("model availability", () => {
       codes,
       `defaultModel "${getDefaultModelCode()}" is deprecated or missing, which breaks session uploads`,
     ).toContain(getDefaultModelCode());
+  });
+
+  it("every task model is selectable and served by the gateway", () => {
+    const codes = new Set(getAvailableModels().map((model) => model.code));
+
+    for (const [role, code] of Object.entries(aiGatewayConfig.taskModels)) {
+      expect(
+        codes.has(code),
+        `taskModels.${role} is "${code}", which is deprecated or missing from the config`,
+      ).toBe(true);
+
+      const gatewayId = resolveGatewayId(code);
+      expect(
+        gatewayIds.has(gatewayId),
+        `taskModels.${role} resolves to "${gatewayId}", which the gateway no longer serves`,
+      ).toBe(true);
+    }
   });
 
   it("has no alias entries for models the config dropped", () => {

--- a/app/modules/llm/__tests__/modelRegistry.test.ts
+++ b/app/modules/llm/__tests__/modelRegistry.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
+import aiGatewayConfig from "~/config/ai_gateway.json";
+import type { TaskModelRole } from "../modelRegistry";
 import {
   findModelByCode,
   getAvailableModels,
   getAvailableProviders,
   getDefaultModelCode,
   getModelPricing,
+  getTaskModelCode,
 } from "../modelRegistry";
 
 describe("modelRegistry", () => {
@@ -88,14 +91,44 @@ describe("modelRegistry", () => {
     });
   });
 
+  describe("getTaskModelCode", () => {
+    const roles = Object.keys(aiGatewayConfig.taskModels) as TaskModelRole[];
+
+    it("the config declares at least one task model role", () => {
+      expect(roles.length).toBeGreaterThan(0);
+    });
+
+    it.each(roles)("%s resolves to a selectable, priced model", (role) => {
+      const code = getTaskModelCode(role);
+
+      expect(
+        findModelByCode(code),
+        `taskModels.${role} is "${code}", which is deprecated or not in providers`,
+      ).not.toBeNull();
+      expect(
+        getModelPricing(code).length,
+        `taskModels.${role} resolves to "${code}", which has no pricing tiers`,
+      ).toBeGreaterThan(0);
+    });
+
+    it("throws for a role the config does not declare", () => {
+      expect(() => getTaskModelCode("notARole" as TaskModelRole)).toThrow(
+        /notARole/,
+      );
+    });
+  });
+
   describe("config validation", () => {
-    it("every model has a non-empty pricing array", () => {
-      const models = getAvailableModels();
-      for (const model of models) {
-        expect(
-          model.pricing?.length,
-          `Model ${model.code} has no pricing tiers`,
-        ).toBeGreaterThan(0);
+    it("every model has a non-empty pricing array, deprecated included", () => {
+      // getAvailableModels() hides deprecated entries, but those keep resolving
+      // for pricing on in-flight runs, so they need the same guarantee.
+      for (const provider of aiGatewayConfig.providers) {
+        for (const model of provider.models) {
+          expect(
+            model.pricing?.length,
+            `Model ${model.code} has no pricing tiers`,
+          ).toBeGreaterThan(0);
+        }
       }
     });
 

--- a/app/modules/llm/llm.ts
+++ b/app/modules/llm/llm.ts
@@ -98,15 +98,21 @@ class LLM {
     if (delta.inputTokens === 0 && delta.outputTokens === 0) return;
     if (!this.options.team) return;
 
+    const applyBillingDebit = (
+      await import("~/modules/billing/services/applyBillingDebit.server")
+    ).default;
+
+    // Deliberately outside the try: a pricing failure means the tokens were
+    // really spent at the provider and we cannot price them, so swallowing it
+    // hands out free usage with nothing but a log line to show for it. Let it
+    // propagate — the callers turn it into an ERRORED session or a 500.
+    const rawAmount = calculateLlmCost({
+      modelCode: this.options.model,
+      inputTokens: delta.inputTokens,
+      outputTokens: delta.outputTokens,
+    });
+
     try {
-      const applyBillingDebit = (
-        await import("~/modules/billing/services/applyBillingDebit.server")
-      ).default;
-      const rawAmount = calculateLlmCost({
-        modelCode: this.options.model,
-        inputTokens: delta.inputTokens,
-        outputTokens: delta.outputTokens,
-      });
       await applyBillingDebit({
         teamId: this.options.team,
         userId: this.options.userId,

--- a/app/modules/llm/modelRegistry.ts
+++ b/app/modules/llm/modelRegistry.ts
@@ -3,6 +3,7 @@ import type { ModelInfo, PricingTier, Provider } from "./model.types";
 
 interface ModelConfig {
   defaultModel: string;
+  taskModels: Record<string, string>;
   providers: Array<{
     name: string;
     models: Array<{
@@ -16,8 +17,40 @@ interface ModelConfig {
 
 const aiGatewayConfig = aiGatewayConfigRaw as unknown as ModelConfig;
 
+export type TaskModelRole =
+  | "promptAlignment"
+  | "promptSuggestions"
+  | "codebookImport";
+
 export function getDefaultModelCode(): string {
   return aiGatewayConfig.defaultModel;
+}
+
+// Model codes are never written in application source — a call that needs a
+// specific model names a role here, so the config stays the only enumeration of
+// codes and modelAvailability.test.ts can cover every one of them. Resolving
+// eagerly against providers turns a config mistake into a loud failure instead
+// of usage the billing path cannot price.
+export function getTaskModelCode(role: TaskModelRole): string {
+  const code = aiGatewayConfig.taskModels?.[role];
+  if (!code) {
+    throw new Error(`No taskModels entry configured for role: ${role}`);
+  }
+
+  const model = findModelByCode(code);
+  if (!model) {
+    throw new Error(
+      `taskModels.${role} is "${code}", which is deprecated or not in providers`,
+    );
+  }
+
+  if (!model.pricing?.length) {
+    throw new Error(
+      `taskModels.${role} is "${code}", which has no pricing and would not be billed`,
+    );
+  }
+
+  return code;
 }
 
 export function getAvailableProviders(): Provider[] {

--- a/app/modules/prompts/services/checkPromptAndAnnotationSchemaAlignment.server.ts
+++ b/app/modules/prompts/services/checkPromptAndAnnotationSchemaAlignment.server.ts
@@ -1,4 +1,5 @@
 import LLM from "~/modules/llm/llm";
+import { getTaskModelCode } from "~/modules/llm/modelRegistry";
 import type { AnnotationSchemaItem } from "../prompts.types";
 
 export default async function checkPromptAndAnnotationSchemaAlignment({
@@ -47,7 +48,7 @@ export default async function checkPromptAndAnnotationSchemaAlignment({
   };
 
   const llm = new LLM({
-    model: "anthropic.claude-4.6-sonnet",
+    model: getTaskModelCode("promptAlignment"),
     team,
     userId,
     source: "prompt-alignment",

--- a/app/modules/prompts/services/suggestPromptAndAnnotationSchemaChanges.server.ts
+++ b/app/modules/prompts/services/suggestPromptAndAnnotationSchemaChanges.server.ts
@@ -1,4 +1,5 @@
 import LLM from "~/modules/llm/llm";
+import { getTaskModelCode } from "~/modules/llm/modelRegistry";
 import type { AnnotationSchemaItem } from "../prompts.types";
 
 export default async function checkPromptAndAnnotationSchemaAlignment({
@@ -60,7 +61,7 @@ export default async function checkPromptAndAnnotationSchemaAlignment({
   };
 
   const llm = new LLM({
-    model: "anthropic.claude-4.6-sonnet",
+    model: getTaskModelCode("promptSuggestions"),
     team,
     userId,
     source: "prompt-alignment",


### PR DESCRIPTION
Fixes #2470

`writeCostRecord` wrapped both the cost calculation and the billing debit in one `try` whose `catch` only warned. `calculateLlmCost` throws whenever pricing cannot be resolved for a model code, and that throw happened before `applyBillingDebit` ran — so any pricing failure meant the tokens were really spent at the provider and the team was charged nothing. `lastFlushedUsage` never advanced either, so nothing retried or reconciled later, and the only trace was a `console.warn` in worker logs.

## What changed

`calculateLlmCost` and the billing service import move outside the `try`, so the error propagates. The `catch` still covers the debit write, which is existing deliberate behaviour with its own test. Callers already handle a throw out of `createChat` the way they handle `InsufficientCreditsError`: the worker tasks mark the run session `ERRORED`, the prompt and codebook services surface a 500.

Runs were already protected — `createRun` and `runSetCreate` price the work through `estimateCost` before starting — but the services that call an LLM directly are not, and three of them named a model code as a literal. A literal is invisible to `modelAvailability.test.ts`, which walks the config, so a typo or a retired model would have gone unnoticed until it silently stopped billing.

Those codes now live in a `taskModels` map alongside `defaultModel` and resolve through `getTaskModelCode`, which rejects a role whose code is missing from `providers` or has no pricing. With every code the app can send enumerated in one place, the config tests cover all of them and the propagating path should never fire in practice.

Also extends the pricing assertion to deprecated models, which `getAvailableModels` hides but in-flight runs still price against.

## Notes for review

- Model codes are unchanged. They are stored identities frozen into `billingLedgerEntry.model`, so renaming one would split a model into two identities in spend reporting.
- Propagating was chosen over writing a zero-amount ledger entry flagged for review. There is deliberately no pre-flight pricing check before the provider call — with every code enumerated in config and covered by CI, the throw is a backstop for a cause we did not anticipate, not an expected path.
- Both conventions are documented in `AGENTS.md` under Model Codes.
