### PR TITLE
Fix two billing gaps: OpenAI provider model and adjudication cost gate

### DIFF
--- a/app/modules/evaluations/__tests__/evaluation.route.test.ts
+++ b/app/modules/evaluations/__tests__/evaluation.route.test.ts
@@ -1,8 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { BillingPlanService } from "~/modules/billing/billingPlan";
+import { TeamBillingService } from "~/modules/billing/teamBilling";
 import { EvaluationService } from "~/modules/evaluations/evaluation";
+import { getAvailableProviders } from "~/modules/llm/modelRegistry";
 import { ProjectService } from "~/modules/projects/project";
 import { PromptService } from "~/modules/prompts/prompt";
 import { RunSetService } from "~/modules/runSets/runSet";
+import { SessionService } from "~/modules/sessions/session";
 import { TeamService } from "~/modules/teams/team";
 import { UserService } from "~/modules/users/user";
 import clearDocumentDB from "../../../../test/helpers/clearDocumentDB";
@@ -303,5 +307,154 @@ describe("evaluation.route action - START_ADJUDICATION IDOR protection", () => {
 
     expect(res.init?.status).toBe(400);
     expect(res.data.errors.runs).toBeDefined();
+  });
+});
+
+const testModel = getAvailableProviders()[0].models[0].code;
+
+describe("evaluation.route action - START_ADJUDICATION cost gate", () => {
+  beforeEach(async () => {
+    await clearDocumentDB();
+  });
+
+  async function setupFundedFixture({ withBilling }: { withBilling: boolean }) {
+    const team = await TeamService.create({ name: "Team" });
+    const user = await UserService.create({
+      username: "user",
+      teams: [{ team: team._id, role: "ADMIN" }],
+    });
+    const project = await ProjectService.create({
+      name: "Project",
+      createdBy: user._id,
+      team: team._id,
+    });
+    const session = await SessionService.create({
+      name: "Session",
+      project: project._id,
+    });
+    const run1 = await createTestRun({ name: "Run 1", project: project._id });
+    const run2 = await createTestRun({ name: "Run 2", project: project._id });
+    const runSet = await RunSetService.create({
+      name: "RunSet",
+      project: project._id,
+      annotationType: "PER_UTTERANCE",
+      runs: [run1._id, run2._id],
+      sessions: [session._id],
+    });
+    const evaluation = await EvaluationService.create({
+      name: "Eval",
+      project: project._id,
+      runSet: runSet._id,
+      runs: [run1._id, run2._id],
+    });
+    const prompt = await PromptService.create({
+      name: "Own",
+      annotationType: "PER_UTTERANCE",
+      team: team._id,
+    });
+
+    if (withBilling) {
+      await BillingPlanService.create({
+        name: "Default",
+        markupRate: 1.5,
+        isDefault: true,
+      });
+      await TeamBillingService.setupTeamBilling(team._id);
+    }
+
+    const cookieHeader = await loginUser(user._id);
+    return {
+      team,
+      project,
+      runSet,
+      evaluation,
+      run1,
+      run2,
+      prompt,
+      cookieHeader,
+    };
+  }
+
+  function startAdjudication({
+    team,
+    project,
+    runSet,
+    evaluation,
+    cookieHeader,
+    payload,
+  }: {
+    team: { _id: string };
+    project: { _id: string };
+    runSet: { _id: string };
+    evaluation: { _id: string };
+    cookieHeader: string;
+    payload: Record<string, unknown>;
+  }) {
+    return action({
+      request: new Request("http://localhost/", {
+        method: "POST",
+        headers: { cookie: cookieHeader, "content-type": "application/json" },
+        body: JSON.stringify({ intent: "START_ADJUDICATION", payload }),
+      }),
+      params: {
+        teamId: team._id,
+        projectId: project._id,
+        runSetId: runSet._id,
+        evaluationId: evaluation._id,
+      },
+    } as any);
+  }
+
+  it("returns 402 when the estimated cost exceeds the balance", async () => {
+    const fixture = await setupFundedFixture({ withBilling: true });
+
+    const res = (await startAdjudication({
+      ...fixture,
+      payload: {
+        selectedRuns: [fixture.run1._id, fixture.run2._id],
+        modelCode: testModel,
+        promptId: fixture.prompt._id,
+        promptVersion: 1,
+      },
+    })) as any;
+
+    expect(res.init?.status).toBe(402);
+    expect(res.data.errors.credits).toBeDefined();
+  });
+
+  it("rejects a model code that is not in the config", async () => {
+    const fixture = await setupFundedFixture({ withBilling: true });
+
+    const res = (await startAdjudication({
+      ...fixture,
+      payload: {
+        selectedRuns: [fixture.run1._id, fixture.run2._id],
+        modelCode: "not.a.real.model",
+        promptId: fixture.prompt._id,
+        promptVersion: 1,
+      },
+    })) as any;
+
+    expect(res.init?.status).toBe(400);
+    expect(res.data.errors.model).toBeDefined();
+  });
+
+  it("rejects an unknown model before pricing it, so no billing plan is needed", async () => {
+    // Model validation must come before the estimate: estimateCost throws when
+    // the team has no plan, which would mask the 400 as a 500.
+    const fixture = await setupFundedFixture({ withBilling: false });
+
+    const res = (await startAdjudication({
+      ...fixture,
+      payload: {
+        selectedRuns: [fixture.run1._id, fixture.run2._id],
+        modelCode: "not.a.real.model",
+        promptId: fixture.prompt._id,
+        promptVersion: 1,
+      },
+    })) as any;
+
+    expect(res.init?.status).toBe(400);
+    expect(res.data.errors.model).toBeDefined();
   });
 });

--- a/app/modules/evaluations/containers/evaluation.route.tsx
+++ b/app/modules/evaluations/containers/evaluation.route.tsx
@@ -17,6 +17,8 @@ import AdjudicationDialogContainer from "~/modules/evaluations/containers/adjudi
 import { EvaluationService } from "~/modules/evaluations/evaluation";
 import getTopPerformersVsGoldLabel from "~/modules/evaluations/helpers/getTopPerformersVsGoldLabel";
 
+import { TeamBillingService } from "~/modules/billing/teamBilling";
+import { findModelByCode } from "~/modules/llm/modelRegistry";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import {
   projectRunSetUrl,
@@ -137,6 +139,10 @@ export async function action({ request, params }: Route.ActionArgs) {
 
       const { modelCode, promptId, promptVersion } = payload;
 
+      if (!findModelByCode(modelCode)) {
+        return data({ errors: { model: "Invalid model" } }, { status: 400 });
+      }
+
       const promptDoc = await PromptService.findOne({
         _id: promptId,
         team: params.teamId,
@@ -145,6 +151,41 @@ export async function action({ request, params }: Route.ActionArgs) {
         return data(
           { errors: { prompt: "Prompt not found" } },
           { status: 404 },
+        );
+      }
+
+      // Adjudication annotates the run set's sessions once, with no verification
+      // pass — mirror that here or the gate prices the wrong amount of work.
+      const teamId =
+        typeof project.team === "string" ? project.team : project.team._id;
+      const [balance, estimate] = await Promise.all([
+        TeamBillingService.getBalance(teamId),
+        TeamBillingService.estimateCost({
+          teamId,
+          projectId: params.projectId,
+          sessionIds: runSet.sessions ?? [],
+          definitions: [
+            {
+              key: `${promptId}:${promptVersion}:${modelCode}`,
+              modelCode,
+              prompt: {
+                promptId,
+                promptName: promptDoc.name,
+                version: Number(promptVersion),
+              },
+            },
+          ],
+          shouldRunVerification: false,
+        }),
+      ]);
+      if (estimate.estimatedCost > balance) {
+        return data(
+          {
+            errors: {
+              credits: "Insufficient credits to start an adjudication",
+            },
+          },
+          { status: 402 },
         );
       }
 

--- a/app/modules/llm/providers/__tests__/openAI.test.ts
+++ b/app/modules/llm/providers/__tests__/openAI.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import getLLM from "../../helpers/getLLM";
+import "../openAI.js";
+
+function getOpenAIMethods() {
+  const provider = getLLM("OPEN_AI");
+  if (!provider) throw new Error("OPEN_AI provider was not registered");
+  return provider.methods;
+}
+
+function makeFakeClient(create: ReturnType<typeof vi.fn>) {
+  return { chat: { completions: { create } } };
+}
+
+const completion = {
+  choices: [{ message: { content: JSON.stringify({ result: "ok" }) } }],
+  usage: { prompt_tokens: 120, completion_tokens: 30 },
+};
+
+describe("openAI provider", () => {
+  let create: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    create = vi.fn().mockResolvedValue(completion);
+  });
+
+  it("calls the model it was asked for", async () => {
+    // Billing prices options.model in writeCostRecord, so calling anything else
+    // means we charge for one model and run another.
+    await getOpenAIMethods().createChat({
+      llm: makeFakeClient(create),
+      options: { model: "gpt-5.6-luna" },
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(create).toHaveBeenCalledOnce();
+    expect(create.mock.calls[0][0].model).toBe("gpt-5.6-luna");
+  });
+
+  it("does not fall back to a hardcoded model", async () => {
+    await getOpenAIMethods().createChat({
+      llm: makeFakeClient(create),
+      options: { model: "gpt-5.6-terra" },
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(create.mock.calls[0][0].model).not.toBe("gpt-4o");
+  });
+
+  it("returns parsed content and token usage", async () => {
+    const result = await getOpenAIMethods().createChat({
+      llm: makeFakeClient(create),
+      options: { model: "gpt-5.6-luna" },
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(result.content).toEqual({ result: "ok" });
+    expect(result.usage).toEqual({
+      inputTokens: 120,
+      outputTokens: 30,
+      providerCost: 0,
+    });
+  });
+});

--- a/app/modules/llm/providers/openAI.ts
+++ b/app/modules/llm/providers/openAI.ts
@@ -13,17 +13,18 @@ registerLLM("OPEN_AI", {
   },
   createChat: async ({
     llm,
+    options,
     messages,
     schema,
   }: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     llm: any;
-    options: unknown;
+    options: { model: string };
     messages: Array<{ role: string; content: string }>;
     schema?: object;
   }) => {
     const requestParams: Record<string, unknown> = {
-      model: "gpt-4o",
+      model: options.model,
       messages: messages,
     };
 


### PR DESCRIPTION
Two independent billing gaps found while working on #2470. Both are small and reviewable per commit.

## Send the requested model to the OpenAI provider

The `OPEN_AI` provider hardcoded `gpt-4o` into `requestParams` and never read `options.model`, so every call went to `gpt-4o` whatever the user picked, while `writeCostRecord` priced the run with `calculateLlmCost({ modelCode: options.model })`. It called one model and billed another.

`gpt-4o` is retired, so this path was failing outright rather than merely mis-billing. It now honours `options.model` the way the aiGateway provider does.

Worth knowing: the config carries both gateway-prefixed codes (`openai.gpt-5-mini`) and OpenAI-native ones (`gpt-5.6-luna`), so a prefixed code sent straight to the OpenAI API will 404. That is a loud failure instead of a silent charge for a model we did not run.

Adds provider tests, which did not exist.

## Gate adjudication on cost and validate its model

`START_ADJUDICATION` created and started a run with no billing check at all. `createRun` and `runSetCreate` both estimate the work against the team balance and return 402 when it does not fit; adjudication went straight to `RunService.start`, leaving the per-call `checkBalance` in `llm.ts` as the only gate — and that only fires once the balance has already reached zero.

It also never validated `modelCode`. `createRun` rejects an unknown code with `findModelByCode`, but adjudication passed whatever the client sent through to `RunService.create`, where `findModelByCode` was called only to build a display name and a miss fell back to the raw string. Since the estimate is also what stops an unpriced model reaching the workers, adjudication was missing both protections.

## Notes for review

- Model validation is deliberately ordered **before** the estimate: `estimateCost` throws when the team has no billing plan, so the reverse order would surface a bad model code as a 500. There is a test pinning that ordering.
- The estimate mirrors what adjudication actually runs — the run set's sessions, once, with `shouldRunVerification: false`.
- `calculateEstimate` prices adjudication as an ordinary run, but adjudication also feeds the source runs' annotations to the model, so the estimate under-counts. The existing 1.2–1.8x cost buffer absorbs part of it. Tracked separately rather than fixed here.
