### PR TITLE
Move model codes out of application source into config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,6 +340,7 @@ A model's `code` is a **stored identity**, not just the name sent to the gateway
 - The gateway renamed its models to provider-native naming and keeps the old names as hidden aliases, so shipped codes keep working. Only **new** models get canonical names. The config therefore mixes both conventions on purpose — do not tidy it up.
 - Retire a model with `"deprecated": true`, never by deleting the entry. Deprecated models stay out of the pickers but keep resolving for pricing and display, which is why `getModelPricing` passes `includeDeprecated`.
 - `defaultModel` must point at a non-deprecated model — session uploads call it with no fallback, so a retired default breaks uploads outright. `modelAvailability.test.ts` guards this and checks every selectable code against a snapshot of the gateway listing; refresh instructions are in `gatewayModels.fixture.json`.
+- **Never write a model code in application source.** A call that needs a specific model declares a role in `taskModels` and resolves it with `getTaskModelCode(role)` (add the role to the `TaskModelRole` union). Keeping the config as the only enumeration of codes is what lets `modelAvailability.test.ts` and `modelRegistry.test.ts` cover every code the app can send — a literal in a service is invisible to both.
 
 ## Path Aliases
 

--- a/app/config/ai_gateway.json
+++ b/app/config/ai_gateway.json
@@ -1,5 +1,10 @@
 {
   "defaultModel": "nto.gemini-3.1-flash-lite",
+  "taskModels": {
+    "promptAlignment": "anthropic.claude-4.6-sonnet",
+    "promptSuggestions": "anthropic.claude-4.6-sonnet",
+    "codebookImport": "anthropic.claude-4.6-opus"
+  },
   "providers": [
     {
       "name": "Google",

--- a/app/modules/codebooks/services/createPromptFromCodebook.server.ts
+++ b/app/modules/codebooks/services/createPromptFromCodebook.server.ts
@@ -1,6 +1,7 @@
 import type { AnnotationTypeOptions } from "~/modules/annotations/helpers/annotationTypes";
 import handleLLMError from "~/modules/llm/helpers/handleLLMError";
 import LLM from "~/modules/llm/llm";
+import { getTaskModelCode } from "~/modules/llm/modelRegistry";
 import { PromptService } from "~/modules/prompts/prompt";
 import { PromptVersionService } from "~/modules/prompts/promptVersion";
 import { CodebookService } from "../codebook";
@@ -72,7 +73,7 @@ export default async function createPromptFromCodebook({
     };
 
     const llm = new LLM({
-      model: "anthropic.claude-4.6-opus",
+      model: getTaskModelCode("codebookImport"),
       team: teamId,
       userId,
       source: "codebook-prompt-generation",

--- a/app/modules/llm/__tests__/modelAvailability.test.ts
+++ b/app/modules/llm/__tests__/modelAvailability.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import aiGatewayConfig from "~/config/ai_gateway.json";
 import { getAvailableModels, getDefaultModelCode } from "../modelRegistry";
 import gatewayModels from "./gatewayModels.fixture.json";
 
@@ -43,6 +44,23 @@ describe("model availability", () => {
       codes,
       `defaultModel "${getDefaultModelCode()}" is deprecated or missing, which breaks session uploads`,
     ).toContain(getDefaultModelCode());
+  });
+
+  it("every task model is selectable and served by the gateway", () => {
+    const codes = new Set(getAvailableModels().map((model) => model.code));
+
+    for (const [role, code] of Object.entries(aiGatewayConfig.taskModels)) {
+      expect(
+        codes.has(code),
+        `taskModels.${role} is "${code}", which is deprecated or missing from the config`,
+      ).toBe(true);
+
+      const gatewayId = resolveGatewayId(code);
+      expect(
+        gatewayIds.has(gatewayId),
+        `taskModels.${role} resolves to "${gatewayId}", which the gateway no longer serves`,
+      ).toBe(true);
+    }
   });
 
   it("has no alias entries for models the config dropped", () => {

--- a/app/modules/llm/__tests__/modelRegistry.test.ts
+++ b/app/modules/llm/__tests__/modelRegistry.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
+import aiGatewayConfig from "~/config/ai_gateway.json";
+import type { TaskModelRole } from "../modelRegistry";
 import {
   findModelByCode,
   getAvailableModels,
   getAvailableProviders,
   getDefaultModelCode,
   getModelPricing,
+  getTaskModelCode,
 } from "../modelRegistry";
 
 describe("modelRegistry", () => {
@@ -88,14 +91,44 @@ describe("modelRegistry", () => {
     });
   });
 
+  describe("getTaskModelCode", () => {
+    const roles = Object.keys(aiGatewayConfig.taskModels) as TaskModelRole[];
+
+    it("the config declares at least one task model role", () => {
+      expect(roles.length).toBeGreaterThan(0);
+    });
+
+    it.each(roles)("%s resolves to a selectable, priced model", (role) => {
+      const code = getTaskModelCode(role);
+
+      expect(
+        findModelByCode(code),
+        `taskModels.${role} is "${code}", which is deprecated or not in providers`,
+      ).not.toBeNull();
+      expect(
+        getModelPricing(code).length,
+        `taskModels.${role} resolves to "${code}", which has no pricing tiers`,
+      ).toBeGreaterThan(0);
+    });
+
+    it("throws for a role the config does not declare", () => {
+      expect(() => getTaskModelCode("notARole" as TaskModelRole)).toThrow(
+        /notARole/,
+      );
+    });
+  });
+
   describe("config validation", () => {
-    it("every model has a non-empty pricing array", () => {
-      const models = getAvailableModels();
-      for (const model of models) {
-        expect(
-          model.pricing?.length,
-          `Model ${model.code} has no pricing tiers`,
-        ).toBeGreaterThan(0);
+    it("every model has a non-empty pricing array, deprecated included", () => {
+      // getAvailableModels() hides deprecated entries, but those keep resolving
+      // for pricing on in-flight runs, so they need the same guarantee.
+      for (const provider of aiGatewayConfig.providers) {
+        for (const model of provider.models) {
+          expect(
+            model.pricing?.length,
+            `Model ${model.code} has no pricing tiers`,
+          ).toBeGreaterThan(0);
+        }
       }
     });
 

--- a/app/modules/llm/modelRegistry.ts
+++ b/app/modules/llm/modelRegistry.ts
@@ -3,6 +3,7 @@ import type { ModelInfo, PricingTier, Provider } from "./model.types";
 
 interface ModelConfig {
   defaultModel: string;
+  taskModels: Record<string, string>;
   providers: Array<{
     name: string;
     models: Array<{
@@ -16,8 +17,40 @@ interface ModelConfig {
 
 const aiGatewayConfig = aiGatewayConfigRaw as unknown as ModelConfig;
 
+export type TaskModelRole =
+  | "promptAlignment"
+  | "promptSuggestions"
+  | "codebookImport";
+
 export function getDefaultModelCode(): string {
   return aiGatewayConfig.defaultModel;
+}
+
+// Model codes are never written in application source — a call that needs a
+// specific model names a role here, so the config stays the only enumeration of
+// codes and modelAvailability.test.ts can cover every one of them. Resolving
+// eagerly against providers turns a config mistake into a loud failure instead
+// of usage the billing path cannot price.
+export function getTaskModelCode(role: TaskModelRole): string {
+  const code = aiGatewayConfig.taskModels?.[role];
+  if (!code) {
+    throw new Error(`No taskModels entry configured for role: ${role}`);
+  }
+
+  const model = findModelByCode(code);
+  if (!model) {
+    throw new Error(
+      `taskModels.${role} is "${code}", which is deprecated or not in providers`,
+    );
+  }
+
+  if (!model.pricing?.length) {
+    throw new Error(
+      `taskModels.${role} is "${code}", which has no pricing and would not be billed`,
+    );
+  }
+
+  return code;
 }
 
 export function getAvailableProviders(): Provider[] {

--- a/app/modules/prompts/services/checkPromptAndAnnotationSchemaAlignment.server.ts
+++ b/app/modules/prompts/services/checkPromptAndAnnotationSchemaAlignment.server.ts
@@ -1,4 +1,5 @@
 import LLM from "~/modules/llm/llm";
+import { getTaskModelCode } from "~/modules/llm/modelRegistry";
 import type { AnnotationSchemaItem } from "../prompts.types";
 
 export default async function checkPromptAndAnnotationSchemaAlignment({
@@ -47,7 +48,7 @@ export default async function checkPromptAndAnnotationSchemaAlignment({
   };
 
   const llm = new LLM({
-    model: "anthropic.claude-4.6-sonnet",
+    model: getTaskModelCode("promptAlignment"),
     team,
     userId,
     source: "prompt-alignment",

--- a/app/modules/prompts/services/suggestPromptAndAnnotationSchemaChanges.server.ts
+++ b/app/modules/prompts/services/suggestPromptAndAnnotationSchemaChanges.server.ts
@@ -1,4 +1,5 @@
 import LLM from "~/modules/llm/llm";
+import { getTaskModelCode } from "~/modules/llm/modelRegistry";
 import type { AnnotationSchemaItem } from "../prompts.types";
 
 export default async function checkPromptAndAnnotationSchemaAlignment({
@@ -60,7 +61,7 @@ export default async function checkPromptAndAnnotationSchemaAlignment({
   };
 
   const llm = new LLM({
-    model: "anthropic.claude-4.6-sonnet",
+    model: getTaskModelCode("promptSuggestions"),
     team,
     userId,
     source: "prompt-alignment",


### PR DESCRIPTION
Follows the discussion on #2470. That issue proposed changing how `writeCostRecord` handles a pricing failure; #2473 tried it and was closed, because once every model code is enumerated in config a wrong config fails in CI and `calculateLlmCost` never gets the chance to throw. This PR is the half that carries the value, without touching `llm.ts`.

## Problem

Three services named a model code as a string literal:

- `suggestPromptAndAnnotationSchemaChanges.server.ts`
- `checkPromptAndAnnotationSchemaAlignment.server.ts`
- `createPromptFromCodebook.server.ts`

`modelAvailability.test.ts` and `modelRegistry.test.ts` both walk `ai_gateway.json`, so a literal in a service is invisible to them. A typo, or a code retired from the config, would have gone unnoticed until it reached the gateway or the pricing lookup at runtime.

## What changed

Those codes move into a `taskModels` map alongside `defaultModel` and resolve through `getTaskModelCode`, which rejects a role whose code is missing from `providers` or has no pricing. With every code the app can send enumerated in one place, the config tests cover all of them, and adding a model code anywhere else is now the thing that stands out.

`modelAvailability.test.ts` gains a check that every `taskModels` code is selectable and still served by the gateway, mirroring the existing `defaultModel` test and reusing `resolveGatewayId`. `modelRegistry.test.ts` gains coverage of every role the config declares. Neither hardcodes a model code — both walk the config, which is the point.

Also extends the pricing assertion to deprecated models. It ran on `getAvailableModels`, which filters them out, but deprecated models keep resolving for pricing on in-flight runs, so they need the same guarantee.

## Notes for review

- Model codes themselves are unchanged. They are stored identities frozen into `run.snapshot.model.code` and `billingLedgerEntry.model`, so renaming one would split a model into two identities in spend reporting.
- `llm.ts` and `llm.test.ts` are untouched. The `try` in `writeCostRecord` still swallows as it does on `main`.
- No closing keyword for #2470 on purpose — that issue is about the swallow, which this does not change. Worth deciding separately whether it stays open.
- Verified by pointing a `taskModels` entry at a typo'd code and confirming both guards fail, then reverting.
