### PR TITLE
Type human annotation values on import

### DIFF
--- a/app/modules/humanAnnotations/__tests__/buildAnnotationSchemaFromHeaders.test.ts
+++ b/app/modules/humanAnnotations/__tests__/buildAnnotationSchemaFromHeaders.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import buildAnnotationSchemaFromHeaders from "../helpers/buildAnnotationSchemaFromHeaders";
+
+describe("buildAnnotationSchemaFromHeaders", () => {
+  it("builds one schema item per annotation field", () => {
+    const headers = [
+      "session_id",
+      "annotator[joe][0]TUTOR_MOVE",
+      "annotator[joe][1]TUTOR_MOVE",
+      "annotator[bob][0]REASONING",
+    ];
+
+    const result = buildAnnotationSchemaFromHeaders(headers, {});
+
+    expect(result).toEqual([
+      {
+        fieldKey: "TUTOR_MOVE",
+        fieldType: "string",
+        value: "",
+        isSystem: false,
+      },
+      {
+        fieldKey: "REASONING",
+        fieldType: "string",
+        value: "",
+        isSystem: false,
+      },
+    ]);
+  });
+
+  it("carries the declared field type and a matching default value", () => {
+    const headers = [
+      "annotator[joe][0]IS_QUESTION",
+      "annotator[joe][0]SCORE",
+      "annotator[joe][0]TUTOR_MOVE",
+    ];
+
+    const result = buildAnnotationSchemaFromHeaders(headers, {
+      IS_QUESTION: "boolean",
+      SCORE: "number",
+      TUTOR_MOVE: "string",
+    });
+
+    expect(result).toEqual([
+      {
+        fieldKey: "IS_QUESTION",
+        fieldType: "boolean",
+        value: false,
+        isSystem: false,
+      },
+      { fieldKey: "SCORE", fieldType: "number", value: 0, isSystem: false },
+      {
+        fieldKey: "TUTOR_MOVE",
+        fieldType: "string",
+        value: "",
+        isSystem: false,
+      },
+    ]);
+  });
+
+  it("ignores headers that are not annotation columns", () => {
+    const result = buildAnnotationSchemaFromHeaders(
+      ["session_id", "sequence_id", "role", "content"],
+      {},
+    );
+
+    expect(result).toEqual([]);
+  });
+});

--- a/app/modules/humanAnnotations/__tests__/buildAnnotationsForUtterance.test.ts
+++ b/app/modules/humanAnnotations/__tests__/buildAnnotationsForUtterance.test.ts
@@ -6,7 +6,13 @@ describe("buildAnnotationsForUtterance", () => {
     const row = { "annotator[joe][0]TUTOR_MOVE": "EXPLAIN" };
     const headers = ["annotator[joe][0]TUTOR_MOVE"];
 
-    const result = buildAnnotationsForUtterance(row, "utt-1", "joe", headers);
+    const result = buildAnnotationsForUtterance(
+      row,
+      "utt-1",
+      "joe",
+      headers,
+      {},
+    );
 
     expect(result).toEqual([
       { _id: "utt-1", identifiedBy: "HUMAN", TUTOR_MOVE: "EXPLAIN" },
@@ -23,7 +29,13 @@ describe("buildAnnotationsForUtterance", () => {
       "annotator[joe][0]REASONING",
     ];
 
-    const result = buildAnnotationsForUtterance(row, "utt-1", "joe", headers);
+    const result = buildAnnotationsForUtterance(
+      row,
+      "utt-1",
+      "joe",
+      headers,
+      {},
+    );
 
     expect(result).toEqual([
       {
@@ -49,7 +61,13 @@ describe("buildAnnotationsForUtterance", () => {
       "annotator[joe][1]REASONING",
     ];
 
-    const result = buildAnnotationsForUtterance(row, "utt-1", "joe", headers);
+    const result = buildAnnotationsForUtterance(
+      row,
+      "utt-1",
+      "joe",
+      headers,
+      {},
+    );
 
     expect(result).toEqual([
       {
@@ -67,11 +85,17 @@ describe("buildAnnotationsForUtterance", () => {
     ]);
   });
 
-  it("preserves '0' as a valid annotation value", () => {
+  it("keeps '0' as a string when the field has no known type", () => {
     const row = { "annotator[joe][0]score": "0" };
     const headers = ["annotator[joe][0]score"];
 
-    const result = buildAnnotationsForUtterance(row, "utt-1", "joe", headers);
+    const result = buildAnnotationsForUtterance(
+      row,
+      "utt-1",
+      "joe",
+      headers,
+      {},
+    );
 
     expect(result).toEqual([
       { _id: "utt-1", identifiedBy: "HUMAN", score: "0" },
@@ -82,7 +106,13 @@ describe("buildAnnotationsForUtterance", () => {
     const row = { "annotator[joe][0]TUTOR_MOVE": "" };
     const headers = ["annotator[joe][0]TUTOR_MOVE"];
 
-    const result = buildAnnotationsForUtterance(row, "utt-1", "joe", headers);
+    const result = buildAnnotationsForUtterance(
+      row,
+      "utt-1",
+      "joe",
+      headers,
+      {},
+    );
 
     expect(result).toEqual([]);
   });
@@ -94,10 +124,93 @@ describe("buildAnnotationsForUtterance", () => {
     };
     const headers = ["annotator[joe][0]field", "annotator[bob][0]field"];
 
-    const result = buildAnnotationsForUtterance(row, "utt-1", "joe", headers);
+    const result = buildAnnotationsForUtterance(
+      row,
+      "utt-1",
+      "joe",
+      headers,
+      {},
+    );
 
     expect(result).toEqual([
       { _id: "utt-1", identifiedBy: "HUMAN", field: "A" },
     ]);
+  });
+  it("coerces a boolean field written as FALSE", () => {
+    const row = { "annotator[joe][0]IS_QUESTION": "FALSE" };
+    const headers = ["annotator[joe][0]IS_QUESTION"];
+
+    const result = buildAnnotationsForUtterance(row, "utt-1", "joe", headers, {
+      IS_QUESTION: "boolean",
+    });
+
+    expect(result).toEqual([
+      { _id: "utt-1", identifiedBy: "HUMAN", IS_QUESTION: false },
+    ]);
+  });
+
+  it("coerces a boolean field written as 1", () => {
+    const row = { "annotator[joe][0]IS_QUESTION": "1" };
+    const headers = ["annotator[joe][0]IS_QUESTION"];
+
+    const result = buildAnnotationsForUtterance(row, "utt-1", "joe", headers, {
+      IS_QUESTION: "boolean",
+    });
+
+    expect(result).toEqual([
+      { _id: "utt-1", identifiedBy: "HUMAN", IS_QUESTION: true },
+    ]);
+  });
+
+  it("coerces a number field, keeping 0", () => {
+    const row = { "annotator[joe][0]score": "0" };
+    const headers = ["annotator[joe][0]score"];
+
+    const result = buildAnnotationsForUtterance(row, "utt-1", "joe", headers, {
+      score: "number",
+    });
+
+    expect(result).toEqual([{ _id: "utt-1", identifiedBy: "HUMAN", score: 0 }]);
+  });
+
+  it("leaves a string field untouched", () => {
+    const row = { "annotator[joe][0]TUTOR_MOVE": "EXPLAIN" };
+    const headers = ["annotator[joe][0]TUTOR_MOVE"];
+
+    const result = buildAnnotationsForUtterance(row, "utt-1", "joe", headers, {
+      TUTOR_MOVE: "string",
+    });
+
+    expect(result).toEqual([
+      { _id: "utt-1", identifiedBy: "HUMAN", TUTOR_MOVE: "EXPLAIN" },
+    ]);
+  });
+
+  it("throws on a value that does not match its field type", () => {
+    const row = {
+      "annotator[joe][0]IS_QUESTION": "maybe",
+      "annotator[joe][0]TUTOR_MOVE": "EXPLAIN",
+    };
+    const headers = [
+      "annotator[joe][0]IS_QUESTION",
+      "annotator[joe][0]TUTOR_MOVE",
+    ];
+
+    expect(() =>
+      buildAnnotationsForUtterance(row, "utt-1", "joe", headers, {
+        IS_QUESTION: "boolean",
+      }),
+    ).toThrow(/IS_QUESTION expects boolean values but found "maybe"/);
+  });
+
+  it("names the utterance in the error so a bad row can be found", () => {
+    const row = { "annotator[joe][0]SCORE": "high" };
+    const headers = ["annotator[joe][0]SCORE"];
+
+    expect(() =>
+      buildAnnotationsForUtterance(row, "utt-42", "joe", headers, {
+        SCORE: "number",
+      }),
+    ).toThrow(/utt-42/);
   });
 });

--- a/app/modules/humanAnnotations/__tests__/coerceAnnotationValue.test.ts
+++ b/app/modules/humanAnnotations/__tests__/coerceAnnotationValue.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import coerceAnnotationValue from "../helpers/coerceAnnotationValue";
+
+describe("coerceAnnotationValue", () => {
+  describe("boolean fields", () => {
+    it.each([
+      ["true", true],
+      ["TRUE", true],
+      ["True", true],
+      ["1", true],
+      ["yes", true],
+      ["YES", true],
+      ["y", true],
+      ["false", false],
+      ["FALSE", false],
+      ["False", false],
+      ["0", false],
+      ["no", false],
+      ["NO", false],
+      ["n", false],
+    ])("coerces %s to %s", (raw, expected) => {
+      expect(coerceAnnotationValue(raw, "boolean")).toEqual({
+        ok: true,
+        value: expected,
+      });
+    });
+
+    it("ignores surrounding whitespace", () => {
+      expect(coerceAnnotationValue("  FALSE  ", "boolean")).toEqual({
+        ok: true,
+        value: false,
+      });
+    });
+
+    it("rejects a value it cannot read as a boolean", () => {
+      expect(coerceAnnotationValue("maybe", "boolean")).toEqual({ ok: false });
+    });
+
+    it("rejects a number that is not 0 or 1", () => {
+      expect(coerceAnnotationValue("2", "boolean")).toEqual({ ok: false });
+    });
+  });
+
+  describe("number fields", () => {
+    it("coerces an integer", () => {
+      expect(coerceAnnotationValue("3", "number")).toEqual({
+        ok: true,
+        value: 3,
+      });
+    });
+
+    it("coerces zero", () => {
+      expect(coerceAnnotationValue("0", "number")).toEqual({
+        ok: true,
+        value: 0,
+      });
+    });
+
+    it("coerces a decimal", () => {
+      expect(coerceAnnotationValue("2.5", "number")).toEqual({
+        ok: true,
+        value: 2.5,
+      });
+    });
+
+    it("coerces a negative number", () => {
+      expect(coerceAnnotationValue("-1", "number")).toEqual({
+        ok: true,
+        value: -1,
+      });
+    });
+
+    it("ignores surrounding whitespace", () => {
+      expect(coerceAnnotationValue(" 4 ", "number")).toEqual({
+        ok: true,
+        value: 4,
+      });
+    });
+
+    it("rejects a value it cannot read as a number", () => {
+      expect(coerceAnnotationValue("high", "number")).toEqual({ ok: false });
+    });
+
+    it("rejects Infinity", () => {
+      expect(coerceAnnotationValue("Infinity", "number")).toEqual({
+        ok: false,
+      });
+    });
+  });
+
+  describe("string and unknown fields", () => {
+    it("passes a string field through unchanged", () => {
+      expect(coerceAnnotationValue("EXPLAIN", "string")).toEqual({
+        ok: true,
+        value: "EXPLAIN",
+      });
+    });
+
+    it("keeps a numeric string when the field is a string", () => {
+      expect(coerceAnnotationValue("0", "string")).toEqual({
+        ok: true,
+        value: "0",
+      });
+    });
+
+    it("passes through when the field type is unknown", () => {
+      expect(coerceAnnotationValue("FALSE", undefined)).toEqual({
+        ok: true,
+        value: "FALSE",
+      });
+    });
+  });
+});

--- a/app/modules/humanAnnotations/__tests__/extractAnnotationCsvMeta.test.ts
+++ b/app/modules/humanAnnotations/__tests__/extractAnnotationCsvMeta.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import extractAnnotationCsvMeta from "../helpers/extractAnnotationCsvMeta";
+
+describe("extractAnnotationCsvMeta", () => {
+  it("collects headers, annotators, fields and session ids", () => {
+    const csv = [
+      "session_id,sequence_id,annotator[joe][0]IS_QUESTION",
+      "session-a.json,1,TRUE",
+      "session-b.json,1,FALSE",
+    ].join("\n");
+
+    const meta = extractAnnotationCsvMeta(csv);
+
+    expect(meta.annotators).toEqual(["joe"]);
+    expect(meta.annotationFields).toEqual(["IS_QUESTION"]);
+    expect(meta.sessionIds).toEqual(["session-a.json", "session-b.json"]);
+  });
+
+  it("collects the distinct values used for each annotation field", () => {
+    const csv = [
+      "session_id,annotator[joe][0]IS_QUESTION,annotator[bob][0]IS_QUESTION",
+      "session-a.json,TRUE,FALSE",
+      "session-a.json,TRUE,TRUE",
+    ].join("\n");
+
+    const meta = extractAnnotationCsvMeta(csv);
+
+    expect(meta.valuesByField).toEqual({ IS_QUESTION: ["TRUE", "FALSE"] });
+  });
+
+  it("keeps values from different fields apart", () => {
+    const csv = [
+      "annotator[joe][0]IS_QUESTION,annotator[joe][0]SCORE",
+      "TRUE,3",
+    ].join("\n");
+
+    const meta = extractAnnotationCsvMeta(csv);
+
+    expect(meta.valuesByField).toEqual({
+      IS_QUESTION: ["TRUE"],
+      SCORE: ["3"],
+    });
+  });
+
+  it("excludes empty cells", () => {
+    const csv = [
+      "annotator[joe][0]IS_QUESTION",
+      "TRUE",
+      "",
+      "  ",
+      "FALSE",
+    ].join("\n");
+
+    const meta = extractAnnotationCsvMeta(csv);
+
+    expect(meta.valuesByField).toEqual({ IS_QUESTION: ["TRUE", "FALSE"] });
+  });
+
+  it("caps how many distinct values it collects per field", () => {
+    const rows = Array.from({ length: 80 }, (_, i) => `value-${i}`);
+    const csv = ["annotator[joe][0]TUTOR_MOVE", ...rows].join("\n");
+
+    const meta = extractAnnotationCsvMeta(csv);
+
+    expect(meta.valuesByField.TUTOR_MOVE).toHaveLength(50);
+  });
+
+  it("returns empty collections for empty input", () => {
+    expect(extractAnnotationCsvMeta("")).toEqual({
+      headers: [],
+      annotators: [],
+      annotationFields: [],
+      sessionIds: [],
+      valuesByField: {},
+    });
+  });
+});

--- a/app/modules/humanAnnotations/__tests__/findInvalidAnnotationValues.test.ts
+++ b/app/modules/humanAnnotations/__tests__/findInvalidAnnotationValues.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import findInvalidAnnotationValues from "../helpers/findInvalidAnnotationValues";
+
+describe("findInvalidAnnotationValues", () => {
+  it("returns nothing when every value matches its field type", () => {
+    const result = findInvalidAnnotationValues(
+      { IS_QUESTION: ["TRUE", "FALSE"], SCORE: ["1", "2"] },
+      { IS_QUESTION: "boolean", SCORE: "number" },
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("reports the values a boolean field cannot read", () => {
+    const result = findInvalidAnnotationValues(
+      { IS_QUESTION: ["TRUE", "maybe", "unsure"] },
+      { IS_QUESTION: "boolean" },
+    );
+
+    expect(result).toEqual([
+      {
+        fieldKey: "IS_QUESTION",
+        fieldType: "boolean",
+        values: ["maybe", "unsure"],
+      },
+    ]);
+  });
+
+  it("reports the values a number field cannot read", () => {
+    const result = findInvalidAnnotationValues(
+      { SCORE: ["3", "high"] },
+      { SCORE: "number" },
+    );
+
+    expect(result).toEqual([
+      { fieldKey: "SCORE", fieldType: "number", values: ["high"] },
+    ]);
+  });
+
+  it("reports each failing field separately", () => {
+    const result = findInvalidAnnotationValues(
+      { IS_QUESTION: ["maybe"], SCORE: ["high"] },
+      { IS_QUESTION: "boolean", SCORE: "number" },
+    );
+
+    expect(result).toEqual([
+      { fieldKey: "IS_QUESTION", fieldType: "boolean", values: ["maybe"] },
+      { fieldKey: "SCORE", fieldType: "number", values: ["high"] },
+    ]);
+  });
+
+  it("accepts anything for a string field", () => {
+    const result = findInvalidAnnotationValues(
+      { TUTOR_MOVE: ["EXPLAIN", "0", "maybe"] },
+      { TUTOR_MOVE: "string" },
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("accepts anything for a field with no declared type", () => {
+    const result = findInvalidAnnotationValues(
+      { NEW_FIELD: ["maybe"] },
+      { IS_QUESTION: "boolean" },
+    );
+
+    expect(result).toEqual([]);
+  });
+});

--- a/app/modules/humanAnnotations/__tests__/getAnnotationFieldTypes.test.ts
+++ b/app/modules/humanAnnotations/__tests__/getAnnotationFieldTypes.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type { Run } from "~/modules/runs/runs.types";
+import getAnnotationFieldTypes from "../helpers/getAnnotationFieldTypes";
+
+function buildRun(
+  annotationSchema: Array<{
+    fieldKey: string;
+    fieldType?: string;
+    isSystem?: boolean;
+  }>,
+  isHuman = false,
+): Run {
+  return {
+    isHuman,
+    snapshot: {
+      prompt: {
+        annotationSchema: annotationSchema.map((field) => ({
+          value: "",
+          isSystem: field.isSystem ?? false,
+          fieldKey: field.fieldKey,
+          fieldType: field.fieldType,
+        })),
+      },
+    },
+  } as unknown as Run;
+}
+
+describe("getAnnotationFieldTypes", () => {
+  it("reads field types from a run snapshot", () => {
+    const runs = [
+      buildRun([
+        { fieldKey: "IS_QUESTION", fieldType: "boolean" },
+        { fieldKey: "SCORE", fieldType: "number" },
+        { fieldKey: "TUTOR_MOVE", fieldType: "string" },
+      ]),
+    ];
+
+    expect(getAnnotationFieldTypes(runs)).toEqual({
+      IS_QUESTION: "boolean",
+      SCORE: "number",
+      TUTOR_MOVE: "string",
+    });
+  });
+
+  it("merges field types across runs", () => {
+    const runs = [
+      buildRun([{ fieldKey: "IS_QUESTION", fieldType: "boolean" }]),
+      buildRun([{ fieldKey: "SCORE", fieldType: "number" }]),
+    ];
+
+    expect(getAnnotationFieldTypes(runs)).toEqual({
+      IS_QUESTION: "boolean",
+      SCORE: "number",
+    });
+  });
+
+  it("skips system fields", () => {
+    const runs = [
+      buildRun([
+        { fieldKey: "_id", fieldType: "string", isSystem: true },
+        { fieldKey: "IS_QUESTION", fieldType: "boolean" },
+      ]),
+    ];
+
+    expect(getAnnotationFieldTypes(runs)).toEqual({ IS_QUESTION: "boolean" });
+  });
+
+  it("ignores human runs, whose schema is inferred from a CSV", () => {
+    const runs = [
+      buildRun([{ fieldKey: "IS_QUESTION", fieldType: "string" }], true),
+      buildRun([{ fieldKey: "IS_QUESTION", fieldType: "boolean" }]),
+    ];
+
+    expect(getAnnotationFieldTypes(runs)).toEqual({ IS_QUESTION: "boolean" });
+  });
+
+  it("falls back to string when two runs disagree on a field type", () => {
+    const runs = [
+      buildRun([{ fieldKey: "SCORE", fieldType: "number" }]),
+      buildRun([{ fieldKey: "SCORE", fieldType: "boolean" }]),
+    ];
+
+    expect(getAnnotationFieldTypes(runs)).toEqual({ SCORE: "string" });
+  });
+
+  it("omits fields with no declared type", () => {
+    const runs = [buildRun([{ fieldKey: "TUTOR_MOVE" }])];
+
+    expect(getAnnotationFieldTypes(runs)).toEqual({});
+  });
+
+  it("returns an empty map when no runs have a snapshot schema", () => {
+    expect(getAnnotationFieldTypes([{} as Run])).toEqual({});
+  });
+
+  it("keeps the declared type for field names inherited from Object", () => {
+    const runs = [
+      buildRun([
+        { fieldKey: "constructor", fieldType: "boolean" },
+        { fieldKey: "__proto__", fieldType: "number" },
+        { fieldKey: "toString", fieldType: "boolean" },
+      ]),
+    ];
+
+    const fieldTypes = getAnnotationFieldTypes(runs);
+
+    expect(fieldTypes["constructor"]).toBe("boolean");
+    expect(fieldTypes["__proto__"]).toBe("number");
+    expect(fieldTypes["toString"]).toBe("boolean");
+  });
+});

--- a/app/modules/humanAnnotations/__tests__/goldLabelAgreement.test.ts
+++ b/app/modules/humanAnnotations/__tests__/goldLabelAgreement.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import calculateCohensKappa from "~/modules/evaluations/helpers/calculateCohensKappa";
+import extractAnnotationValues from "~/modules/evaluations/helpers/extractAnnotationValues";
+import type { SessionFile } from "~/modules/sessions/sessions.types";
+import buildAnnotationsForUtterance from "../helpers/buildAnnotationsForUtterance";
+
+// Evaluations compare annotation values as strings, so an untyped "TRUE" from a
+// human CSV never matches the `true` an LLM run holds — the gold label scores
+// zero agreement with a run it actually agrees with
+
+function buildSession(annotationsPerUtterance: unknown[][]): SessionFile {
+  return {
+    transcript: annotationsPerUtterance.map((annotations, i) => ({
+      _id: `utt-${i}`,
+      annotations,
+    })),
+  } as unknown as SessionFile;
+}
+
+const HEADERS = ["annotator[joe][0]IS_QUESTION"];
+const CSV_ROWS = [
+  { "annotator[joe][0]IS_QUESTION": "TRUE" },
+  { "annotator[joe][0]IS_QUESTION": "FALSE" },
+  { "annotator[joe][0]IS_QUESTION": "TRUE" },
+  { "annotator[joe][0]IS_QUESTION": "FALSE" },
+];
+
+const LLM_RUN = buildSession([
+  [{ _id: "utt-0", identifiedBy: "LLM", IS_QUESTION: true }],
+  [{ _id: "utt-1", identifiedBy: "LLM", IS_QUESTION: false }],
+  [{ _id: "utt-2", identifiedBy: "LLM", IS_QUESTION: true }],
+  [{ _id: "utt-3", identifiedBy: "LLM", IS_QUESTION: false }],
+]);
+
+function getKappaAgainstLLMRun(fieldTypes: Record<string, string>): number {
+  const humanRun = buildSession(
+    CSV_ROWS.map((row, i) =>
+      buildAnnotationsForUtterance(row, `utt-${i}`, "joe", HEADERS, fieldTypes),
+    ),
+  );
+
+  return calculateCohensKappa(
+    extractAnnotationValues(humanRun, "PER_UTTERANCE", "IS_QUESTION"),
+    extractAnnotationValues(LLM_RUN, "PER_UTTERANCE", "IS_QUESTION"),
+  );
+}
+
+describe("gold label agreement with an LLM run", () => {
+  it("scores no agreement when the boolean field has no declared type", () => {
+    expect(getKappaAgainstLLMRun({})).toBe(0);
+  });
+
+  it("scores full agreement when the field is typed as boolean", () => {
+    expect(getKappaAgainstLLMRun({ IS_QUESTION: "boolean" })).toBe(1);
+  });
+});

--- a/app/modules/humanAnnotations/__tests__/humanAnnotations.route.test.ts
+++ b/app/modules/humanAnnotations/__tests__/humanAnnotations.route.test.ts
@@ -11,6 +11,11 @@ import { action } from "../containers/humanAnnotations.route";
 
 const mockUpload = vi.fn().mockResolvedValue(undefined);
 
+const mocks = vi.hoisted(() => ({
+  analyzeHumanCsv: vi.fn(),
+  createHumanRun: vi.fn(),
+}));
+
 vi.mock("~/modules/storage/helpers/getStorageAdapter", () => ({
   default: () => ({
     upload: mockUpload,
@@ -21,13 +26,11 @@ vi.mock("~/modules/storage/helpers/getStorageAdapter", () => ({
 }));
 
 vi.mock("~/modules/humanAnnotations/services/analyzeHumanCsv.server", () => ({
-  default: vi
-    .fn()
-    .mockResolvedValue({ missingSessionNames: [], matchedSessions: [] }),
+  default: mocks.analyzeHumanCsv,
 }));
 
 vi.mock("~/modules/humanAnnotations/services/createHumanRun.server", () => ({
-  default: vi.fn().mockResolvedValue({ _id: new Types.ObjectId().toString() }),
+  default: mocks.createHumanRun,
 }));
 
 vi.mock(
@@ -41,9 +44,20 @@ describe("humanAnnotations.route action - UPLOAD_HUMAN_CSV", () => {
   beforeEach(async () => {
     await clearDocumentDB();
     mockUpload.mockClear();
+    mocks.analyzeHumanCsv.mockReset().mockResolvedValue({
+      missingSessionNames: [],
+      matchedSessions: [],
+      fieldTypes: {},
+    });
+    mocks.createHumanRun
+      .mockReset()
+      .mockResolvedValue({ _id: new Types.ObjectId().toString() });
   });
 
-  async function setupAndUpload(filename: string) {
+  async function setupAndUpload(
+    filename: string,
+    csvContent = "col1,col2\nval1,val2",
+  ) {
     const team = await TeamService.create({ name: "Team" });
     const user = await UserService.create({
       username: "admin",
@@ -77,10 +91,10 @@ describe("humanAnnotations.route action - UPLOAD_HUMAN_CSV", () => {
     );
     formData.append(
       "file",
-      new File(["col1,col2\nval1,val2"], filename, { type: "text/csv" }),
+      new File([csvContent], filename, { type: "text/csv" }),
     );
 
-    await action({
+    const response = await action({
       request: new Request(
         "http://localhost/api/humanAnnotations/" + runSet._id,
         {
@@ -92,7 +106,7 @@ describe("humanAnnotations.route action - UPLOAD_HUMAN_CSV", () => {
       params: { runSetId: runSet._id },
     } as any);
 
-    return { runSet };
+    return { runSet, response };
   }
 
   it("sanitizes path traversal sequences in the uploaded filename", async () => {
@@ -114,5 +128,20 @@ describe("humanAnnotations.route action - UPLOAD_HUMAN_CSV", () => {
 
     expect(path.basename(uploadPath)).toBe("annotations.csv");
     expect(uploadPath).not.toContain("..");
+  });
+
+  it("stores the CSV and creates the run for a valid upload", async () => {
+    vi.spyOn(RunSetService, "addRunsToRunSet").mockResolvedValue({
+      errors: [],
+    } as never);
+
+    const { response } = await setupAndUpload(
+      "annotations.csv",
+      "session_id,annotator[joe][0]IS_QUESTION\nsession-a.json,FALSE",
+    );
+
+    expect((response.data as any).success).toBe(true);
+    expect(mockUpload).toHaveBeenCalledOnce();
+    expect(mocks.createHumanRun).toHaveBeenCalledOnce();
   });
 });

--- a/app/modules/humanAnnotations/components/previewCsvStep.tsx
+++ b/app/modules/humanAnnotations/components/previewCsvStep.tsx
@@ -97,10 +97,36 @@ const PreviewCsvStep = ({
           {analysisResult.annotationFields.map((field) => (
             <Badge key={field} variant="outline">
               {field}
+              {analysisResult.fieldTypes[field] && (
+                <span className="text-muted-foreground">
+                  &nbsp;· {analysisResult.fieldTypes[field]}
+                </span>
+              )}
             </Badge>
           ))}
         </div>
       </div>
+      {analysisResult.invalidValues.length > 0 && (
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>
+            <div className="grid gap-1">
+              <span>
+                Some values do not match the field types used by the runs in
+                this run set. Fix them in the CSV and upload again.
+              </span>
+              {analysisResult.invalidValues.map((field) => (
+                <span key={field.fieldKey} className="wrap-break-word">
+                  <strong>{field.fieldKey}</strong>
+                  &nbsp;expects&nbsp;{field.fieldType}
+                  &nbsp;values but the CSV contains:&nbsp;
+                  {field.values.join(", ")}
+                </span>
+              ))}
+            </div>
+          </AlertDescription>
+        </Alert>
+      )}
     </div>
   );
 };

--- a/app/modules/humanAnnotations/components/uploadHumanAnnotationsDialog.tsx
+++ b/app/modules/humanAnnotations/components/uploadHumanAnnotationsDialog.tsx
@@ -47,7 +47,11 @@ const UploadHumanAnnotationsDialog = ({
     analyzeFetcher.submit(
       JSON.stringify({
         intent: "ANALYZE_HUMAN_CSV",
-        payload: { headers: meta.headers, sessionIds: meta.sessionIds },
+        payload: {
+          headers: meta.headers,
+          sessionIds: meta.sessionIds,
+          valuesByField: meta.valuesByField,
+        },
       }),
       {
         method: "POST",
@@ -105,7 +109,8 @@ const UploadHumanAnnotationsDialog = ({
                 isAnalyzing ||
                 !analysisResult ||
                 analysisResult.matchedSessions.length === 0 ||
-                analysisResult.missingSessionNames.length > 0
+                analysisResult.missingSessionNames.length > 0 ||
+                analysisResult.invalidValues.length > 0
               }
               onClick={() => {
                 if (csvFile && csvMeta) {

--- a/app/modules/humanAnnotations/containers/humanAnnotations.route.tsx
+++ b/app/modules/humanAnnotations/containers/humanAnnotations.route.tsx
@@ -37,6 +37,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       const result = await analyzeHumanCsv({
         headers: payload.headers,
         sessionIds: payload.sessionIds,
+        valuesByField: payload.valuesByField,
         runSetId: params.runSetId,
       });
       return data({ success: true, intent, data: result });
@@ -60,6 +61,8 @@ export async function action({ request, params }: Route.ActionArgs) {
 
       const { headers, annotators } = body.payload;
 
+      const csvBuffer = Buffer.from(await file.arrayBuffer());
+
       const analysis = await analyzeHumanCsv({
         headers,
         sessionIds: body.payload.sessionIds,
@@ -78,7 +81,6 @@ export async function action({ request, params }: Route.ActionArgs) {
         );
       }
 
-      const csvBuffer = Buffer.from(await file.arrayBuffer());
       const csvPath = `storage/${runSet.project}/uploads/${path.basename(file.name)}`;
       const storage = getStorageAdapter();
       await storage.upload({
@@ -90,7 +92,10 @@ export async function action({ request, params }: Route.ActionArgs) {
         uploadPath: csvPath,
       });
 
-      const annotationSchema = buildAnnotationSchemaFromHeaders(headers);
+      const annotationSchema = buildAnnotationSchemaFromHeaders(
+        headers,
+        analysis.fieldTypes,
+      );
 
       const matchedSessionIds = analysis.matchedSessions.map((s) => s._id);
       const runIds: string[] = [];
@@ -123,6 +128,7 @@ export async function action({ request, params }: Route.ActionArgs) {
         runIds,
         annotators,
         headers,
+        fieldTypes: analysis.fieldTypes,
         csvPath,
         projectId: runSet.project,
         matchedSessions: analysis.matchedSessions,

--- a/app/modules/humanAnnotations/helpers/buildAnnotationSchemaFromHeaders.ts
+++ b/app/modules/humanAnnotations/helpers/buildAnnotationSchemaFromHeaders.ts
@@ -1,8 +1,15 @@
 import type { AnnotationSchemaItem } from "~/modules/prompts/prompts.types";
 import parseAnnotationColumn from "./parseAnnotationColumns";
 
+function getDefaultValue(fieldType: string): unknown {
+  if (fieldType === "boolean") return false;
+  if (fieldType === "number") return 0;
+  return "";
+}
+
 export default function buildAnnotationSchemaFromHeaders(
   headers: string[],
+  fieldTypes: Record<string, string>,
 ): AnnotationSchemaItem[] {
   const fieldSet = new Set<string>();
 
@@ -12,9 +19,14 @@ export default function buildAnnotationSchemaFromHeaders(
     fieldSet.add(parsed.field);
   }
 
-  return Array.from(fieldSet).map((fieldKey) => ({
-    fieldKey,
-    value: "",
-    isSystem: false,
-  }));
+  return Array.from(fieldSet).map((fieldKey) => {
+    const fieldType = fieldTypes[fieldKey] ?? "string";
+
+    return {
+      fieldKey,
+      fieldType,
+      value: getDefaultValue(fieldType),
+      isSystem: false,
+    };
+  });
 }

--- a/app/modules/humanAnnotations/helpers/buildAnnotationsForUtterance.ts
+++ b/app/modules/humanAnnotations/helpers/buildAnnotationsForUtterance.ts
@@ -1,3 +1,4 @@
+import coerceAnnotationValue from "./coerceAnnotationValue";
 import parseAnnotationColumn from "./parseAnnotationColumns";
 
 interface AnnotationObject {
@@ -11,9 +12,10 @@ export default function buildAnnotationsForUtterance(
   utteranceId: string,
   annotator: string,
   headers: string[],
+  fieldTypes: Record<string, string>,
 ): AnnotationObject[] {
   // Group columns by index — each index produces one annotation object
-  const groups = new Map<number, Record<string, string>>();
+  const groups = new Map<number, Record<string, unknown>>();
 
   for (const header of headers) {
     const parsed = parseAnnotationColumn(header);
@@ -22,11 +24,20 @@ export default function buildAnnotationsForUtterance(
     const value = row[header];
     if (value === undefined || value === "") continue;
 
+    const coerced = coerceAnnotationValue(value, fieldTypes[parsed.field]);
+    if (!coerced.ok) {
+      // Fail the run rather than drop the cell — a silently missing gold label
+      // shrinks the set that agreement is scored over with nobody told
+      throw new Error(
+        `${parsed.field} expects ${fieldTypes[parsed.field]} values but found "${value}" on utterance ${utteranceId}`,
+      );
+    }
+
     if (!groups.has(parsed.index)) {
       groups.set(parsed.index, {});
     }
 
-    groups.get(parsed.index)![parsed.field] = value;
+    groups.get(parsed.index)![parsed.field] = coerced.value;
   }
 
   const annotations: AnnotationObject[] = [];

--- a/app/modules/humanAnnotations/helpers/coerceAnnotationValue.ts
+++ b/app/modules/humanAnnotations/helpers/coerceAnnotationValue.ts
@@ -1,0 +1,26 @@
+export type CoercionResult = { ok: true; value: unknown } | { ok: false };
+
+const TRUE_VALUES = new Set(["true", "1", "yes", "y"]);
+const FALSE_VALUES = new Set(["false", "0", "no", "n"]);
+
+export default function coerceAnnotationValue(
+  raw: string,
+  fieldType?: string,
+): CoercionResult {
+  const trimmed = raw.trim();
+
+  if (fieldType === "boolean") {
+    const normalized = trimmed.toLowerCase();
+    if (TRUE_VALUES.has(normalized)) return { ok: true, value: true };
+    if (FALSE_VALUES.has(normalized)) return { ok: true, value: false };
+    return { ok: false };
+  }
+
+  if (fieldType === "number") {
+    const parsed = Number(trimmed);
+    if (trimmed === "" || !Number.isFinite(parsed)) return { ok: false };
+    return { ok: true, value: parsed };
+  }
+
+  return { ok: true, value: raw };
+}

--- a/app/modules/humanAnnotations/helpers/extractAnnotationCsvMeta.ts
+++ b/app/modules/humanAnnotations/helpers/extractAnnotationCsvMeta.ts
@@ -5,7 +5,12 @@ export interface AnnotationCsvMeta {
   annotators: string[];
   annotationFields: string[];
   sessionIds: string[];
+  valuesByField: Record<string, string[]>;
 }
+
+// The preview only samples values, to keep the analyse payload small on long
+// transcripts. The upload action checks every cell before accepting a file
+const MAX_VALUES_PER_FIELD = 50;
 
 // Parses CSV text into rows, correctly handling multi-line quoted fields
 function parseCsvRows(csvText: string): string[][] {
@@ -60,6 +65,7 @@ export default function extractAnnotationCsvMeta(
       annotators: [],
       annotationFields: [],
       sessionIds: [],
+      valuesByField: {},
     };
   }
 
@@ -67,12 +73,38 @@ export default function extractAnnotationCsvMeta(
 
   const annotatorSet = new Set<string>();
   const fieldSet = new Set<string>();
+  const annotationColumns: Array<{ columnIndex: number; field: string }> = [];
 
-  for (const header of headers) {
+  headers.forEach((header, columnIndex) => {
     const parsed = parseAnnotationColumn(header);
-    if (!parsed) continue;
+    if (!parsed) return;
+
     annotatorSet.add(parsed.annotator);
     fieldSet.add(parsed.field);
+    annotationColumns.push({ columnIndex, field: parsed.field });
+  });
+
+  const valueSets = new Map<string, Set<string>>();
+
+  for (let i = 1; i < rows.length; i++) {
+    for (const column of annotationColumns) {
+      const value = rows[i][column.columnIndex];
+      if (!value) continue;
+
+      let values = valueSets.get(column.field);
+      if (!values) {
+        values = new Set<string>();
+        valueSets.set(column.field, values);
+      }
+
+      if (values.size >= MAX_VALUES_PER_FIELD) continue;
+      values.add(value);
+    }
+  }
+
+  const valuesByField: Record<string, string[]> = {};
+  for (const [fieldKey, values] of valueSets) {
+    valuesByField[fieldKey] = Array.from(values);
   }
 
   const sessionIdIndex = headers.indexOf("session_id");
@@ -92,5 +124,6 @@ export default function extractAnnotationCsvMeta(
     annotators: Array.from(annotatorSet),
     annotationFields: Array.from(fieldSet),
     sessionIds: Array.from(sessionIdSet),
+    valuesByField,
   };
 }

--- a/app/modules/humanAnnotations/helpers/findInvalidAnnotationValues.ts
+++ b/app/modules/humanAnnotations/helpers/findInvalidAnnotationValues.ts
@@ -1,0 +1,27 @@
+import type { InvalidAnnotationField } from "../humanAnnotations.types";
+import coerceAnnotationValue from "./coerceAnnotationValue";
+
+export default function findInvalidAnnotationValues(
+  valuesByField: Record<string, string[]>,
+  fieldTypes: Record<string, string>,
+): InvalidAnnotationField[] {
+  const invalidFields: InvalidAnnotationField[] = [];
+
+  for (const [fieldKey, values] of Object.entries(valuesByField)) {
+    const fieldType = fieldTypes[fieldKey];
+    if (!fieldType || fieldType === "string") continue;
+    if (!Array.isArray(values)) continue;
+
+    const invalidValues = values.filter(
+      (value) =>
+        typeof value === "string" &&
+        !coerceAnnotationValue(value, fieldType).ok,
+    );
+
+    if (invalidValues.length > 0) {
+      invalidFields.push({ fieldKey, fieldType, values: invalidValues });
+    }
+  }
+
+  return invalidFields;
+}

--- a/app/modules/humanAnnotations/helpers/getAnnotationFieldTypes.ts
+++ b/app/modules/humanAnnotations/helpers/getAnnotationFieldTypes.ts
@@ -1,0 +1,30 @@
+import type { Run } from "~/modules/runs/runs.types";
+
+export default function getAnnotationFieldTypes(
+  runs: Run[],
+): Record<string, string> {
+  // Null-prototype: a field named `constructor` or `__proto__` would otherwise
+  // read an inherited value here and resolve to the wrong type
+  const fieldTypes: Record<string, string> = Object.create(null);
+
+  for (const run of runs) {
+    if (run.isHuman) continue;
+
+    const schema = run.snapshot?.prompt?.annotationSchema;
+    if (!schema) continue;
+
+    for (const field of schema) {
+      if (field.isSystem || !field.fieldType) continue;
+
+      const existing = fieldTypes[field.fieldKey];
+      if (existing && existing !== field.fieldType) {
+        fieldTypes[field.fieldKey] = "string";
+        continue;
+      }
+
+      fieldTypes[field.fieldKey] = field.fieldType;
+    }
+  }
+
+  return fieldTypes;
+}

--- a/app/modules/humanAnnotations/humanAnnotations.types.ts
+++ b/app/modules/humanAnnotations/humanAnnotations.types.ts
@@ -1,9 +1,17 @@
+export interface InvalidAnnotationField {
+  fieldKey: string;
+  fieldType: string;
+  values: string[];
+}
+
 export interface AnalysisResult {
   annotators: string[];
   annotationFields: string[];
   matchedSessions: { sessionId: string; name: string; _id: string }[];
   unmatchedSessionIds: string[];
   missingSessionNames: string[];
+  fieldTypes: Record<string, string>;
+  invalidValues: InvalidAnnotationField[];
 }
 
 export interface AnnotationTemplateField {

--- a/app/modules/humanAnnotations/services/analyzeHumanCsv.server.ts
+++ b/app/modules/humanAnnotations/services/analyzeHumanCsv.server.ts
@@ -1,11 +1,16 @@
+import { RunService } from "~/modules/runs/run";
 import { RunSetService } from "~/modules/runSets/runSet";
 import { SessionService } from "~/modules/sessions/session";
+import findInvalidAnnotationValues from "../helpers/findInvalidAnnotationValues";
+import getAnnotationFieldTypes from "../helpers/getAnnotationFieldTypes";
 import parseAnnotationColumn from "../helpers/parseAnnotationColumns";
+import type { InvalidAnnotationField } from "../humanAnnotations.types";
 
 interface AnalyzeHumanCsvProps {
   headers: string[];
   sessionIds: string[];
   runSetId: string;
+  valuesByField?: Record<string, string[]>;
 }
 
 interface MatchedSession {
@@ -20,12 +25,15 @@ interface AnalyzeHumanCsvResult {
   matchedSessions: MatchedSession[];
   unmatchedSessionIds: string[];
   missingSessionNames: string[];
+  fieldTypes: Record<string, string>;
+  invalidValues: InvalidAnnotationField[];
 }
 
 export default async function analyzeHumanCsv({
   headers,
   sessionIds,
   runSetId,
+  valuesByField = {},
 }: AnalyzeHumanCsvProps): Promise<AnalyzeHumanCsvResult> {
   const annotatorSet = new Set<string>();
   const fieldSet = new Set<string>();
@@ -45,6 +53,14 @@ export default async function analyzeHumanCsv({
   const sessions = await SessionService.find({
     match: { _id: { $in: runSet.sessions } },
   });
+
+  const runs = runSet.runs?.length
+    ? await RunService.find({
+        match: { _id: { $in: runSet.runs } },
+        select: "snapshot.prompt.annotationSchema isHuman",
+      })
+    : [];
+  const fieldTypes = getAnnotationFieldTypes(runs);
 
   const matchedSessions: MatchedSession[] = [];
   const unmatchedSessionIds: string[] = [];
@@ -76,5 +92,7 @@ export default async function analyzeHumanCsv({
     matchedSessions,
     unmatchedSessionIds,
     missingSessionNames: missingSessions.map((s) => s.name),
+    fieldTypes,
+    invalidValues: findInvalidAnnotationValues(valuesByField, fieldTypes),
   };
 }

--- a/app/modules/humanAnnotations/services/uploadHumanAnnotations.server.ts
+++ b/app/modules/humanAnnotations/services/uploadHumanAnnotations.server.ts
@@ -11,6 +11,7 @@ interface UploadHumanAnnotationsProps {
   runIds: string[];
   annotators: string[];
   headers: string[];
+  fieldTypes: Record<string, string>;
   csvPath: string;
   projectId: string;
   matchedSessions: MatchedSession[];
@@ -20,6 +21,7 @@ export default async function uploadHumanAnnotations({
   runIds,
   annotators,
   headers,
+  fieldTypes,
   csvPath,
   projectId,
   matchedSessions,
@@ -46,6 +48,7 @@ export default async function uploadHumanAnnotations({
         sessionName: session.name,
         annotator,
         headers,
+        fieldTypes,
         csvPath,
         inputFile: `storage/${projectId}/preAnalysis/${session._id}/${session.name}`,
         outputFolder: `storage/${projectId}/runs/${runId}/${session._id}`,

--- a/scripts/evaluations/csvToEvaluation.ts
+++ b/scripts/evaluations/csvToEvaluation.ts
@@ -128,6 +128,9 @@ async function main() {
           utteranceId,
           runId,
           headers,
+          // This script never reads the database, so it has no annotation
+          // schema to type against and every value stays a string
+          {},
         );
         runAnnotationCount += annotations.length;
         return {

--- a/workers/tasks/processUploadHumanAnnotations.ts
+++ b/workers/tasks/processUploadHumanAnnotations.ts
@@ -16,6 +16,7 @@ export default async function processUploadHumanAnnotations(job: Job) {
     sessionName,
     annotator,
     headers,
+    fieldTypes,
     csvPath,
     inputFile,
     outputFolder,
@@ -73,6 +74,8 @@ export default async function processUploadHumanAnnotations(job: Job) {
         utterance._id,
         annotator,
         headers,
+        // Jobs already queued when this deployed have no fieldTypes in their data
+        fieldTypes ?? {},
       );
 
       utterance.annotations = [


### PR DESCRIPTION
Fixes #2465

## The problem

Human gold-label CSVs were imported with every cell as a string. `buildAnnotationsForUtterance` copied `row[header]` verbatim, so a boolean gold label was stored as the string `"FALSE"` while the LLM runs in the same run set held a real `false`.

The reporter's screenshot is the mildest symptom — the session viewer renders strings as text and non-strings as a checkbox, so the gold label looked different from the LLM annotation. The damage was in evaluations:

- `extractAnnotationValues` stringifies values, and `calculateCohensKappa` / `calculatePRF1` compare them with strict equality as categories. `"TRUE"` never equals `"true"`, and `"1"` equals neither, so a gold label scored no agreement with a run it agreed with completely, silently.
- Lowercase `true`/`false` matched by accident, which is why reformatting attempts gave inconsistent results rather than consistently failing.
- Exports (`outputRunDataToCSV`/`ToJSON`) passed values through raw, so a run set export mixed `false` and `"FALSE"` in one column and downstream tools read it as text.

`app/modules/humanAnnotations/__tests__/goldLabelAgreement.test.ts` pins this down: kappa is 0 for an untyped gold label and 1 for the same labels typed.

## The fix

Prompt annotation schemas already declare a `fieldType` (`string` / `number` / `boolean`), and a human run is always uploaded into a run set, so the sibling LLM runs are the authority on what each field should be.

- `getAnnotationFieldTypes` resolves those types from the run set's non-human runs. System fields are skipped, and two runs disagreeing on a field falls back to `string` so nothing is coerced on a guess.
- Values are coerced during import: a boolean field accepts `TRUE`/`FALSE`, `1`/`0` and `yes`/`no` case-insensitively; a number field parses finite numbers; string and unknown-type fields pass through unchanged.
- The human run's snapshot schema now carries the resolved `fieldType` and a matching default value instead of claiming every field is a string.
- The preview shows each field's expected type and lists mismatches, with **Upload & Process** disabled while any exist.

## Where the check lives

A cell that cannot be read **fails the run**, naming the field, the value and the utterance.

The check runs in the worker rather than in the upload action, because the worker downloads and parses the CSV regardless and already walks every cell through the coercion. Validating in the action meant parsing the whole file a second time, synchronously, on the SSR request path, purely to turn a background failure into a `400`.

Failing is deliberate over skipping the cell. A silently dropped gold label shrinks the set that agreement is scored over with nobody told, which is a quieter version of the bug this PR is fixing.

The normal path still gets feedback before anything is uploaded: the preview samples distinct values client-side and disables the button on a mismatch. Reaching the worker with a bad cell means the UI was bypassed, so a failed run is a proportionate outcome there.

## Deployment notes

- Human runs uploaded before this change keep their string values and need a re-upload to score correctly. There is no migration — existing session JSON in storage is left alone.
- `processUploadHumanAnnotations` defaults `fieldTypes` to `{}`, so jobs already queued when this deploys keep their current behaviour instead of failing.
- `scripts/evaluations/csvToEvaluation.ts` never reads the database, so it has no schema to type against and its values stay strings.
