### PR TITLE
Send the requested model to the OpenAI provider, validate the adjudication model code

### DIFF
--- a/app/modules/evaluations/__tests__/evaluation.route.test.ts
+++ b/app/modules/evaluations/__tests__/evaluation.route.test.ts
@@ -126,48 +126,48 @@ describe("evaluation.route loader - IDOR protection", () => {
   });
 });
 
+async function setupSingleTeamFixture() {
+  const team = await TeamService.create({ name: "Team" });
+  const user = await UserService.create({
+    username: "user",
+    teams: [{ team: team._id, role: "ADMIN" }],
+  });
+  const project = await ProjectService.create({
+    name: "Project",
+    createdBy: user._id,
+    team: team._id,
+  });
+  const run1 = await createTestRun({ name: "Run 1", project: project._id });
+  const run2 = await createTestRun({ name: "Run 2", project: project._id });
+  const runSet = await RunSetService.create({
+    name: "RunSet",
+    project: project._id,
+    annotationType: "PER_UTTERANCE",
+    runs: [run1._id, run2._id],
+  });
+  const evaluation = await EvaluationService.create({
+    name: "Eval",
+    project: project._id,
+    runSet: runSet._id,
+    runs: [run1._id, run2._id],
+  });
+  const cookieHeader = await loginUser(user._id);
+  return {
+    team,
+    user,
+    project,
+    run1,
+    run2,
+    runSet,
+    evaluation,
+    cookieHeader,
+  };
+}
+
 describe("evaluation.route action - START_ADJUDICATION IDOR protection", () => {
   beforeEach(async () => {
     await clearDocumentDB();
   });
-
-  async function setupSingleTeamFixture() {
-    const team = await TeamService.create({ name: "Team" });
-    const user = await UserService.create({
-      username: "user",
-      teams: [{ team: team._id, role: "ADMIN" }],
-    });
-    const project = await ProjectService.create({
-      name: "Project",
-      createdBy: user._id,
-      team: team._id,
-    });
-    const run1 = await createTestRun({ name: "Run 1", project: project._id });
-    const run2 = await createTestRun({ name: "Run 2", project: project._id });
-    const runSet = await RunSetService.create({
-      name: "RunSet",
-      project: project._id,
-      annotationType: "PER_UTTERANCE",
-      runs: [run1._id, run2._id],
-    });
-    const evaluation = await EvaluationService.create({
-      name: "Eval",
-      project: project._id,
-      runSet: runSet._id,
-      runs: [run1._id, run2._id],
-    });
-    const cookieHeader = await loginUser(user._id);
-    return {
-      team,
-      user,
-      project,
-      run1,
-      run2,
-      runSet,
-      evaluation,
-      cookieHeader,
-    };
-  }
 
   it("rejects when promptId belongs to a different team", async () => {
     const {
@@ -303,5 +303,46 @@ describe("evaluation.route action - START_ADJUDICATION IDOR protection", () => {
 
     expect(res.init?.status).toBe(400);
     expect(res.data.errors.runs).toBeDefined();
+  });
+});
+
+describe("evaluation.route action - START_ADJUDICATION model validation", () => {
+  beforeEach(async () => {
+    await clearDocumentDB();
+  });
+
+  it("rejects a model code that is not in the config", async () => {
+    const { team, project, runSet, evaluation, run1, run2, cookieHeader } =
+      await setupSingleTeamFixture();
+    const prompt = await PromptService.create({
+      name: "Own",
+      annotationType: "PER_UTTERANCE",
+      team: team._id,
+    });
+
+    const res = (await action({
+      request: new Request("http://localhost/", {
+        method: "POST",
+        headers: { cookie: cookieHeader, "content-type": "application/json" },
+        body: JSON.stringify({
+          intent: "START_ADJUDICATION",
+          payload: {
+            selectedRuns: [run1._id, run2._id],
+            modelCode: "not.a.real.model",
+            promptId: prompt._id,
+            promptVersion: 1,
+          },
+        }),
+      }),
+      params: {
+        teamId: team._id,
+        projectId: project._id,
+        runSetId: runSet._id,
+        evaluationId: evaluation._id,
+      },
+    } as any)) as any;
+
+    expect(res.init?.status).toBe(400);
+    expect(res.data.errors.model).toBeDefined();
   });
 });

--- a/app/modules/evaluations/containers/evaluation.route.tsx
+++ b/app/modules/evaluations/containers/evaluation.route.tsx
@@ -17,6 +17,7 @@ import AdjudicationDialogContainer from "~/modules/evaluations/containers/adjudi
 import { EvaluationService } from "~/modules/evaluations/evaluation";
 import getTopPerformersVsGoldLabel from "~/modules/evaluations/helpers/getTopPerformersVsGoldLabel";
 
+import { findModelByCode } from "~/modules/llm/modelRegistry";
 import ProjectAuthorization from "~/modules/projects/authorization";
 import {
   projectRunSetUrl,
@@ -136,6 +137,10 @@ export async function action({ request, params }: Route.ActionArgs) {
       }
 
       const { modelCode, promptId, promptVersion } = payload;
+
+      if (!findModelByCode(modelCode)) {
+        return data({ errors: { model: "Invalid model" } }, { status: 400 });
+      }
 
       const promptDoc = await PromptService.findOne({
         _id: promptId,

--- a/app/modules/llm/providers/__tests__/openAI.test.ts
+++ b/app/modules/llm/providers/__tests__/openAI.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import getLLM from "../../helpers/getLLM";
+import "../openAI.js";
+
+function getOpenAIMethods() {
+  const provider = getLLM("OPEN_AI");
+  if (!provider) throw new Error("OPEN_AI provider was not registered");
+  return provider.methods;
+}
+
+function makeFakeClient(create: ReturnType<typeof vi.fn>) {
+  return { chat: { completions: { create } } };
+}
+
+const completion = {
+  choices: [{ message: { content: JSON.stringify({ result: "ok" }) } }],
+  usage: { prompt_tokens: 120, completion_tokens: 30 },
+};
+
+describe("openAI provider", () => {
+  let create: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    create = vi.fn().mockResolvedValue(completion);
+  });
+
+  it("calls the model it was asked for", async () => {
+    // Billing prices options.model in writeCostRecord, so calling anything else
+    // means we charge for one model and run another.
+    await getOpenAIMethods().createChat({
+      llm: makeFakeClient(create),
+      options: { model: "gpt-5.6-luna" },
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(create).toHaveBeenCalledOnce();
+    expect(create.mock.calls[0][0].model).toBe("gpt-5.6-luna");
+  });
+
+  it("does not fall back to a hardcoded model", async () => {
+    await getOpenAIMethods().createChat({
+      llm: makeFakeClient(create),
+      options: { model: "gpt-5.6-terra" },
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(create.mock.calls[0][0].model).not.toBe("gpt-4o");
+  });
+
+  it("returns parsed content and token usage", async () => {
+    const result = await getOpenAIMethods().createChat({
+      llm: makeFakeClient(create),
+      options: { model: "gpt-5.6-luna" },
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(result.content).toEqual({ result: "ok" });
+    expect(result.usage).toEqual({
+      inputTokens: 120,
+      outputTokens: 30,
+      providerCost: 0,
+    });
+  });
+});

--- a/app/modules/llm/providers/openAI.ts
+++ b/app/modules/llm/providers/openAI.ts
@@ -13,17 +13,18 @@ registerLLM("OPEN_AI", {
   },
   createChat: async ({
     llm,
+    options,
     messages,
     schema,
   }: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     llm: any;
-    options: unknown;
+    options: { model: string };
     messages: Array<{ role: string; content: string }>;
     schema?: object;
   }) => {
     const requestParams: Record<string, unknown> = {
-      model: "gpt-4o",
+      model: options.model,
       messages: messages,
     };
 


### PR DESCRIPTION
Two independent fixes found while working on #2470. One commit each.

## Send the requested model to the OpenAI provider

The `OPEN_AI` provider hardcoded `gpt-4o` into `requestParams` and never read `options.model`, so every call went to `gpt-4o` whatever the user picked, while `writeCostRecord` priced the run with `calculateLlmCost({ modelCode: options.model })`. It called one model and billed another.

`gpt-4o` is retired, so this path was failing outright rather than merely mis-billing. It now honours `options.model` the way the aiGateway provider does.

Worth knowing: the config carries both gateway-prefixed codes (`openai.gpt-5-mini`) and OpenAI-native ones, so a prefixed code sent straight to the OpenAI API will 404. That is a loud failure instead of a silent charge for a model we did not run.

Adds provider tests, which did not exist.

## Validate the adjudication model code

`START_ADJUDICATION` took `modelCode` straight from the payload and passed it to `createAdjudicationRun`, which stores it on the run and hands it to the worker. `findModelByCode` was called there only to build a display name, and a miss fell back to the raw string, so an unknown code got as far as the LLM call — after the run and the run set update had already been written.

It now rejects at the action boundary with 400 `errors.model`, the way `createRun.route.tsx` does.

`setupSingleTeamFixture` moves to module scope so the new describe can reuse it rather than duplicate it. That is the deletion in the test diff; the block is unchanged apart from indentation.

## On the cost gate

`START_ADJUDICATION` also has no upfront balance check, unlike `createRun` and `runSetCreate`. I wrote one mirroring `createRun` and then dropped it, because `estimateCost` prices adjudication as an ordinary run and adjudication does not do an ordinary run's work:

- Sessions where all source runs agree make **no LLM call at all** — the annotations are copied from the first source run (`adjudicatePerUtterance.ts:73`, and the same in `adjudicatePerSession.ts`). A mirrored gate would refuse, for insufficient credits, an adjudication that costs nothing.
- Sessions that disagree carry `adjudicationContext` — every conflicting annotation from every source run — on top of prompt and transcript (`adjudicatePerUtterance.ts:115`). `calculateEstimate` sums only session and prompt-version `inputTokens`, so that block is unpriced.

The figure the gate compared against the balance was wrong in both directions, so it would have blocked free work and let through underpriced work. Agreement is only discoverable by loading every source run's session files, which is what the worker does, so an honest gate needs an adjudication mode in `calculateEstimate` rather than a copy of the `createRun` call. #2475 covers the under-count half; the false-block half is new and is why I did not ship it as an approximation.

Until then `checkBalance` in `llm.ts` remains the only gate on this path, firing at zero balance mid-run.
