### PR TITLE
Fix redirect issue on re-login

### DIFF
--- a/app/modules/authentication/helpers/requireAuth.ts
+++ b/app/modules/authentication/helpers/requireAuth.ts
@@ -9,7 +9,21 @@ export default async function requireAuth({ request }: { request: Request }) {
     const session = await sessionStorage.getSession(
       request.headers.get("cookie"),
     );
-    session.flash("returnTo", pathname + search);
+
+    // Only capture returnTo for real page navigations. React Router revalidates
+    // route loaders and mounted fetcher.load() calls after every mutation — so
+    // signing out fires a batch of unauthenticated data requests, each of which
+    // would otherwise write its own path as returnTo (last response wins) and
+    // dump the user on a JSON resource route after signing back in.
+    // Sec-Fetch-Mode is absent for non-browser clients, so treat that as a
+    // navigation; the /api/ check covers those cases.
+    const fetchMode = request.headers.get("Sec-Fetch-Mode");
+    const isDataRequest = fetchMode !== null && fetchMode !== "navigate";
+
+    if (!isDataRequest && !pathname.startsWith("/api/")) {
+      session.flash("returnTo", pathname + search);
+    }
+
     throw redirect("/signup", {
       headers: { "Set-Cookie": await sessionStorage.commitSession(session) },
     });

--- a/app/modules/authentication/helpers/sanitizeReturnTo.ts
+++ b/app/modules/authentication/helpers/sanitizeReturnTo.ts
@@ -7,5 +7,9 @@ export default function sanitizeReturnTo(value: unknown): string {
     value.startsWith("/\\")
   )
     return "/";
+  // Resource routes (loader-only, no default export) render as a broken page on
+  // a document request, and /auth/* would restart the OAuth handshake. Rejecting
+  // them here also heals sessions already holding a poisoned returnTo.
+  if (value.startsWith("/api/") || value.startsWith("/auth/")) return "/";
   return value;
 }


### PR DESCRIPTION
fixes #2479 
This pull request improves how user navigation is handled during authentication and enhances security around redirect destinations. The main changes ensure that users are redirected to appropriate pages after signing in, avoiding broken pages or unintended routes, and that only valid navigation events update the intended return path.

**Authentication flow improvements:**

- Only set the `returnTo` session value for real page navigations (not for background data requests or API calls), preventing users from being redirected to non-UI or resource routes after login.

**Security and redirect validation:**

- Updated `sanitizeReturnTo` to reject `/api/` and `/auth/` paths as redirect destinations, preventing navigation to resource or authentication endpoints after login and healing any sessions with invalid return paths.